### PR TITLE
Add hierarchy tree diff for plan review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ Categories
 │   │   ├── Akismet (2)  ✕ retire → plugins
 │   │   └── WooCommerce (12)
 │   └── Themes (30)
-│       └── Full Site Editing  ★ new
+│       └── Full Site Editing (0)  ★ new
 └── WP (3)  → merge into wordpress
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,7 +233,7 @@ Use what you learned from analyzing posts to write descriptions that reflect the
 Before presenting the flat table, generate a hierarchy tree using `render_category_tree()` from `lib/helpers.py`. This shows parent-child relationships and makes structural consequences visible at a glance — especially when retiring or merging categories that have children.
 
 ```python
-from lib.helpers import render_category_tree
+from helpers import render_category_tree
 import json
 
 with open('data/export/categories.json') as f:
@@ -241,6 +241,7 @@ with open('data/export/categories.json') as f:
 
 # Build the actions dict from your analysis:
 actions = {
+    "links": {"action": "retire"},
     "akismet": {"action": "retire", "target": "plugins"},
     "full-site-editing": {"action": "create", "name": "Full Site Editing", "parent_slug": "themes"},
     "wp": {"action": "merge", "target": "wordpress"},
@@ -253,13 +254,16 @@ Example output:
 
 ```
 Categories
+├── Links (23)  ✕ retire  ⚠ 2 children orphaned
+│   ├── Blogroll (10)  ⚠ orphaned
+│   └── Resources (5)  ⚠ orphaned
+├── Personal (89)
 ├── WordPress (150)
 │   ├── Plugins (45)
-│   │   ├── WooCommerce (12)
-│   │   └── Akismet (2)  ✕ retire → plugins
+│   │   ├── Akismet (2)  ✕ retire → plugins
+│   │   └── WooCommerce (12)
 │   └── Themes (30)
 │       └── Full Site Editing  ★ new
-├── Personal (89)
 └── WP (3)  → merge into wordpress
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,11 +256,11 @@ Categories
 ├── WordPress (150)
 │   ├── Plugins (45)
 │   │   ├── WooCommerce (12)
-│   │   └── Akismet (2)                ✕ retire → plugins
+│   │   └── Akismet (2)  ✕ retire → plugins
 │   └── Themes (30)
-│       └── Full Site Editing           ★ new
+│       └── Full Site Editing  ★ new
 ├── Personal (89)
-└── WP (3)                              → merge into wordpress
+└── WP (3)  → merge into wordpress
 ```
 
 If the tree shows `⚠ orphaned` warnings, call these out to the user explicitly. Orphaned categories become root-level categories when their parent is retired — this may not be the intended outcome. Suggest re-parenting or including them in the plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,56 @@ Use what you learned from analyzing posts to write descriptions that reflect the
 3. Improve existing descriptions that are empty, vague, or outdated
 4. The description should help readers understand what they'll find, not just restate the category name
 
+### Hierarchy Tree View
+
+Before presenting the flat table, generate a hierarchy tree using `render_category_tree()` from `lib/helpers.py`. This shows parent-child relationships and makes structural consequences visible at a glance — especially when retiring or merging categories that have children.
+
+```python
+from lib.helpers import render_category_tree
+import json
+
+with open('data/export/categories.json') as f:
+    categories = json.load(f)
+
+# Build the actions dict from your analysis:
+actions = {
+    "akismet": {"action": "retire", "target": "plugins"},
+    "full-site-editing": {"action": "create", "name": "Full Site Editing", "parent_slug": "themes"},
+    "wp": {"action": "merge", "target": "wordpress"},
+}
+
+print(render_category_tree(categories, actions))
+```
+
+Example output:
+
+```
+Categories
+├── WordPress (150)
+│   ├── Plugins (45)
+│   │   ├── WooCommerce (12)
+│   │   └── Akismet (2)                ✕ retire → plugins
+│   └── Themes (30)
+│       └── Full Site Editing           ★ new
+├── Personal (89)
+└── WP (3)                              → merge into wordpress
+```
+
+If the tree shows `⚠ orphaned` warnings, call these out to the user explicitly. Orphaned categories become root-level categories when their parent is retired — this may not be the intended outcome. Suggest re-parenting or including them in the plan.
+
+The actions dict maps category slugs to action descriptors:
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `action` | string | yes | `"keep"`, `"retire"`, `"merge"`, or `"create"` |
+| `target` | string | for merge/retire | Slug of the destination category |
+| `parent_slug` | string | for create | Parent slug (omit for root-level) |
+| `name` | string | for create | Display name of the new category |
+| `count` | int | no | Expected post count (for create actions) |
+| `detail` | string | no | Human-readable context |
+
+Display the tree BEFORE the description table so the user sees the structural view first.
+
 ### Presentation Format
 
 Present the plan and descriptions together as a single table so the user can see everything at once:

--- a/agents/analyze.md
+++ b/agents/analyze.md
@@ -62,3 +62,4 @@ Confidence levels:
 - Be accurate — wrong categories are worse than missing ones
 - **Only suggest categories that are directly about the post's topic.** Do not add a secondary category unless the post genuinely covers that second topic. A post about a specific hobby is not a generic "recreation" post. A bookmarked link is not a "book recommendation". A YouTube tutorial is not "tech" just because it's on YouTube.
 - `new_cats` should only contain truly novel categories that would apply to multiple posts, not one-off topics
+- When suggesting a new category, include a `"parent_slug"` if it logically belongs under an existing category (e.g., a new "Full Site Editing" category belongs under "Themes"). This helps the hierarchy tree view show where new categories fit.

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -605,15 +605,9 @@ def _render_node(node, action_info, is_orphaned):
     """
     name = node['name']
     count = node.get('count', 0)
-    synthetic = node.get('_synthetic', False)
     warning = node.get('_warning')
 
-    if synthetic:
-        label = name
-        if count:
-            label += f' ({count})'
-    else:
-        label = f'{name} ({count})'
+    label = f'{name} ({count})'
 
     parts = [label]
 

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -6,6 +6,7 @@ These run on the user's machine (not on WordPress) and handle:
 - Aggregating analysis results from multiple agent batches
 - Validating data formats (export JSON, suggestion JSON, backup JSON, log TSV)
 - Generating summary statistics from analysis results
+- Rendering hierarchy tree diffs for plan review
 """
 
 import csv
@@ -458,3 +459,286 @@ def parse_change_log(log_path):
     """
     with open(log_path, newline='') as f:
         return list(csv.DictReader(f, delimiter='\t'))
+
+
+def _build_tree(categories, actions=None):
+    """
+    Build a tree structure from a flat list of categories.
+
+    Indexes categories by slug and term_id, builds a parent-child map,
+    and injects synthetic nodes for 'create' actions.
+
+    Args:
+        categories: List of category dicts (term_id, name, slug, count, parent).
+        actions: Optional dict mapping slug to action descriptors.
+
+    Returns:
+        Tuple of (roots, children_map, node_map) where:
+        - roots: sorted list of root-level slugs
+        - children_map: {slug: [child_slugs]} sorted by name
+        - node_map: {slug: category dict}
+    """
+    actions = actions or {}
+    node_map = {}
+    id_to_slug = {}
+
+    for cat in categories:
+        slug = cat['slug']
+        node_map[slug] = cat
+        id_to_slug[cat['term_id']] = slug
+
+    children_map = {}
+    roots = []
+    seen = set()
+
+    for cat in categories:
+        slug = cat['slug']
+        seen.add(slug)
+        parent_id = cat.get('parent', 0)
+        if parent_id == 0:
+            roots.append(slug)
+        else:
+            parent_slug = id_to_slug.get(parent_id)
+            if parent_slug:
+                children_map.setdefault(parent_slug, []).append(slug)
+            else:
+                roots.append(slug)
+                node_map[slug] = {**cat, '_warning': 'parent missing'}
+
+    # Inject synthetic nodes for 'create' actions.
+    for slug, action in actions.items():
+        if action.get('action') != 'create':
+            continue
+        if slug in seen:
+            continue
+        node_map[slug] = {
+            'name': action.get('name', slug.replace('-', ' ').title()),
+            'slug': slug,
+            'count': action.get('count', 0),
+            'parent': 0,
+            '_synthetic': True,
+        }
+        parent_slug = action.get('parent_slug')
+        if parent_slug and parent_slug in node_map:
+            children_map.setdefault(parent_slug, []).append(slug)
+        elif parent_slug:
+            roots.append(slug)
+            node_map[slug]['_warning'] = 'parent not found'
+        else:
+            roots.append(slug)
+
+    # Detect circular parent references.
+    for slug in list(node_map):
+        visited = set()
+        current = slug
+        while current and current in node_map:
+            if current in visited:
+                # Break the cycle: move to root.
+                if current not in roots:
+                    roots.append(current)
+                for parent_slug, child_list in children_map.items():
+                    if current in child_list:
+                        child_list.remove(current)
+                        break
+                node_map[current] = {**node_map[current], '_warning': 'circular'}
+                break
+            visited.add(current)
+            parent_id = node_map[current].get('parent', 0)
+            current = id_to_slug.get(parent_id) if parent_id else None
+
+    # Sort children by name, roots by name.
+    for slug in children_map:
+        children_map[slug].sort(key=lambda s: node_map[s]['name'].lower())
+    roots.sort(key=lambda s: node_map[s]['name'].lower())
+
+    return roots, children_map, node_map
+
+
+def _detect_orphans(children_map, actions):
+    """
+    Find categories whose parent is being retired or merged.
+
+    A category is orphaned if its parent has action 'retire' or 'merge'
+    but the category itself is being kept (or has no action).
+
+    Args:
+        children_map: {slug: [child_slugs]} from _build_tree.
+        actions: Dict mapping slug to action descriptors.
+
+    Returns:
+        Tuple of (orphaned_slugs, orphan_counts) where:
+        - orphaned_slugs: set of slugs that would become orphaned
+        - orphan_counts: {parent_slug: number of orphaned children}
+    """
+    actions = actions or {}
+    orphaned = set()
+    orphan_counts = {}
+
+    for slug, action in actions.items():
+        if action.get('action') not in ('retire', 'merge'):
+            continue
+        children = children_map.get(slug, [])
+        count = 0
+        for child in children:
+            child_action = actions.get(child, {}).get('action', 'keep')
+            if child_action not in ('retire', 'merge'):
+                orphaned.add(child)
+                count += 1
+        if count > 0:
+            orphan_counts[slug] = count
+
+    return orphaned, orphan_counts
+
+
+def _render_node(node, action_info, is_orphaned):
+    """
+    Render a single category node's display text with annotations.
+
+    Args:
+        node: Category dict with at least 'name' and 'count'.
+        action_info: Action dict or None.
+        is_orphaned: Whether this node would become orphaned.
+
+    Returns:
+        String like 'Akismet (2)  ✕ retire → Plugins'
+    """
+    name = node['name']
+    count = node.get('count', 0)
+    synthetic = node.get('_synthetic', False)
+    warning = node.get('_warning')
+
+    if synthetic:
+        label = name
+        if count:
+            label += f' ({count})'
+    else:
+        label = f'{name} ({count})'
+
+    parts = [label]
+
+    if action_info:
+        action = action_info.get('action', 'keep')
+        if action == 'retire':
+            target = action_info.get('target')
+            if target:
+                parts.append(f'\u2715 retire \u2192 {target}')
+            else:
+                parts.append('\u2715 retire')
+        elif action == 'merge':
+            target = action_info.get('target', '?')
+            parts.append(f'\u2192 merge into {target}')
+        elif action == 'create':
+            parts.append('\u2605 new')
+
+    if warning:
+        parts.append(f'\u26a0 {warning}')
+    elif is_orphaned:
+        parts.append('\u26a0 orphaned')
+
+    if action_info and action_info.get('action') in ('retire', 'merge'):
+        orphan_count = action_info.get('_orphan_count', 0)
+        if orphan_count:
+            s = 'child' if orphan_count == 1 else 'children'
+            parts.append(f'\u26a0 {orphan_count} {s} orphaned')
+
+    return '  '.join(parts)
+
+
+def _format_tree_lines(slug, children_map, node_map, actions, orphaned, prefix, is_last):
+    """
+    Recursively render tree lines with box-drawing connectors.
+
+    Args:
+        slug: Current category slug to render.
+        children_map: {slug: [child_slugs]}.
+        node_map: {slug: category dict}.
+        actions: Dict mapping slug to action descriptors.
+        orphaned: Set of orphaned slugs.
+        prefix: String prefix for indentation.
+        is_last: Whether this is the last sibling.
+
+    Returns:
+        List of output strings.
+    """
+    connector = '\u2514\u2500\u2500 ' if is_last else '\u251c\u2500\u2500 '
+    node = node_map[slug]
+    action_info = (actions or {}).get(slug)
+    line = prefix + connector + _render_node(node, action_info, slug in orphaned)
+    lines = [line]
+
+    child_prefix = prefix + ('    ' if is_last else '\u2502   ')
+    children = children_map.get(slug, [])
+    for i, child_slug in enumerate(children):
+        child_is_last = (i == len(children) - 1)
+        lines.extend(_format_tree_lines(
+            child_slug, children_map, node_map, actions,
+            orphaned, child_prefix, child_is_last,
+        ))
+
+    return lines
+
+
+def render_category_tree(categories, actions=None):
+    """
+    Render an annotated ASCII tree of the category hierarchy.
+
+    Shows parent-child relationships with box-drawing characters and
+    annotates proposed changes (retire, merge, create). Detects and
+    warns about categories that would become orphaned.
+
+    Args:
+        categories: List of category dicts from the export/backup JSON.
+            Each dict has: term_id, name, slug, count, parent.
+        actions: Optional dict mapping category slug to an action descriptor:
+            {
+                "action": "keep" | "retire" | "merge" | "create",
+                "target": "merge-target-slug",
+                "parent_slug": "parent-for-new-category",
+                "name": "Display Name (for create)",
+                "count": 0,
+                "detail": "optional context"
+            }
+
+    Returns:
+        Multi-line string showing the hierarchy with annotations.
+    """
+    if not categories and not (actions and any(
+        a.get('action') == 'create' for a in actions.values()
+    )):
+        return '(no categories)'
+
+    roots, children_map, node_map = _build_tree(categories, actions)
+    orphaned, orphan_counts = _detect_orphans(children_map, actions)
+
+    # Inject orphan counts into action_info for rendering.
+    if actions:
+        actions = {slug: {**info} for slug, info in actions.items()}
+        for slug, count in orphan_counts.items():
+            if slug in actions:
+                actions[slug]['_orphan_count'] = count
+
+    if not roots:
+        return '(no categories)'
+
+    # Single root: render directly. Multiple roots: wrap in virtual root.
+    if len(roots) == 1:
+        root = roots[0]
+        node = node_map[root]
+        action_info = (actions or {}).get(root)
+        header = _render_node(node, action_info, root in orphaned)
+        lines = [header]
+        children = children_map.get(root, [])
+        for i, child in enumerate(children):
+            lines.extend(_format_tree_lines(
+                child, children_map, node_map, actions,
+                orphaned, '', i == len(children) - 1,
+            ))
+    else:
+        lines = ['Categories']
+        for i, root in enumerate(roots):
+            lines.extend(_format_tree_lines(
+                root, children_map, node_map, actions,
+                orphaned, '', i == len(roots) - 1,
+            ))
+
+    return '\n'.join(lines)

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -485,7 +485,8 @@ def _build_tree(categories, actions=None):
     for cat in categories:
         slug = cat['slug']
         node_map[slug] = cat
-        id_to_slug[cat['term_id']] = slug
+        # Coerce to int: WordPress APIs may return string IDs.
+        id_to_slug[int(cat['term_id'])] = slug
 
     children_map = {}
     roots = []
@@ -494,7 +495,7 @@ def _build_tree(categories, actions=None):
     for cat in categories:
         slug = cat['slug']
         seen.add(slug)
-        parent_id = cat.get('parent', 0)
+        parent_id = int(cat.get('parent', 0))
         if parent_id == 0:
             roots.append(slug)
         else:
@@ -543,7 +544,7 @@ def _build_tree(categories, actions=None):
                 node_map[current] = {**node_map[current], '_warning': 'circular'}
                 break
             visited.add(current)
-            parent_id = node_map[current].get('parent', 0)
+            parent_id = int(node_map[current].get('parent', 0))
             current = id_to_slug.get(parent_id) if parent_id else None
 
     # Sort children by name, roots by name.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,6 +17,7 @@ from helpers import (
     aggregate_results,
     calculate_batch_size,
     parse_change_log,
+    render_category_tree,
     split_into_batches,
     validate_backup,
     validate_category_slugs,
@@ -643,6 +644,236 @@ class TestValidateCategorySlugs(unittest.TestCase):
         suggestions = [{'post_id': 1, 'cats': []}]
         check = validate_category_slugs(suggestions, {'tech'})
         self.assertTrue(check['valid'])
+
+
+def _cat(term_id, name, slug, count=0, parent=0):
+    """Shorthand for building a category dict in tests."""
+    return {
+        'term_id': term_id,
+        'name': name,
+        'slug': slug,
+        'count': count,
+        'parent': parent,
+    }
+
+
+class TestRenderCategoryTree(unittest.TestCase):
+    """Tests for hierarchy tree diff rendering."""
+
+    def test_empty_categories(self):
+        result = render_category_tree([])
+        self.assertEqual(result, '(no categories)')
+
+    def test_single_root_no_actions(self):
+        cats = [_cat(1, 'WordPress', 'wordpress', 150)]
+        result = render_category_tree(cats)
+        self.assertIn('WordPress (150)', result)
+
+    def test_flat_hierarchy(self):
+        cats = [
+            _cat(1, 'Tech', 'tech', 50),
+            _cat(2, 'Music', 'music', 30),
+            _cat(3, 'Personal', 'personal', 20),
+        ]
+        result = render_category_tree(cats)
+        self.assertIn('Categories', result)
+        self.assertIn('Tech (50)', result)
+        self.assertIn('Music (30)', result)
+        self.assertIn('Personal (20)', result)
+
+    def test_parent_child(self):
+        cats = [
+            _cat(1, 'WordPress', 'wordpress', 150),
+            _cat(2, 'Plugins', 'plugins', 45, parent=1),
+            _cat(3, 'Themes', 'themes', 30, parent=1),
+        ]
+        result = render_category_tree(cats)
+        self.assertIn('WordPress (150)', result)
+        self.assertIn('Plugins (45)', result)
+        self.assertIn('Themes (30)', result)
+        lines = result.split('\n')
+        wp_line = [i for i, l in enumerate(lines) if 'WordPress' in l][0]
+        plugins_line = [i for i, l in enumerate(lines) if 'Plugins' in l][0]
+        self.assertGreater(plugins_line, wp_line)
+
+    def test_deep_nesting(self):
+        cats = [
+            _cat(1, 'Level 1', 'l1', 10),
+            _cat(2, 'Level 2', 'l2', 8, parent=1),
+            _cat(3, 'Level 3', 'l3', 5, parent=2),
+            _cat(4, 'Level 4', 'l4', 2, parent=3),
+        ]
+        result = render_category_tree(cats)
+        self.assertIn('Level 4 (2)', result)
+        lines = result.split('\n')
+        level_lines = [i for i, l in enumerate(lines) if 'Level' in l]
+        self.assertEqual(len(level_lines), 4)
+        child_indents = []
+        for idx in level_lines[1:]:
+            line = lines[idx]
+            indent = len(line) - len(line.lstrip())
+            child_indents.append(indent)
+        for i in range(1, len(child_indents)):
+            self.assertGreater(child_indents[i], child_indents[i - 1])
+
+    def test_retire_annotation(self):
+        cats = [_cat(1, 'Akismet', 'akismet', 2)]
+        actions = {'akismet': {'action': 'retire', 'target': 'plugins'}}
+        result = render_category_tree(cats, actions)
+        self.assertIn('\u2715 retire', result)
+        self.assertIn('plugins', result)
+
+    def test_merge_annotation(self):
+        cats = [_cat(1, 'WP', 'wp', 3)]
+        actions = {'wp': {'action': 'merge', 'target': 'wordpress'}}
+        result = render_category_tree(cats, actions)
+        self.assertIn('\u2192 merge into wordpress', result)
+
+    def test_create_annotation(self):
+        cats = [_cat(1, 'WordPress', 'wordpress', 150)]
+        actions = {'ai': {'action': 'create', 'name': 'AI'}}
+        result = render_category_tree(cats, actions)
+        self.assertIn('\u2605 new', result)
+        self.assertIn('AI', result)
+
+    def test_create_with_parent(self):
+        cats = [
+            _cat(1, 'WordPress', 'wordpress', 150),
+            _cat(2, 'Themes', 'themes', 30, parent=1),
+        ]
+        actions = {
+            'full-site-editing': {
+                'action': 'create',
+                'name': 'Full Site Editing',
+                'parent_slug': 'themes',
+            }
+        }
+        result = render_category_tree(cats, actions)
+        self.assertIn('Full Site Editing', result)
+        lines = result.split('\n')
+        themes_line = next(i for i, l in enumerate(lines) if 'Themes' in l)
+        fse_line = next(i for i, l in enumerate(lines) if 'Full Site Editing' in l)
+        self.assertGreater(fse_line, themes_line)
+
+    def test_orphan_detection(self):
+        cats = [
+            _cat(1, 'Links', 'links', 23),
+            _cat(2, 'Blogroll', 'blogroll', 10, parent=1),
+            _cat(3, 'Resources', 'resources', 5, parent=1),
+        ]
+        actions = {'links': {'action': 'retire'}}
+        result = render_category_tree(cats, actions)
+        self.assertIn('\u26a0', result)
+        self.assertIn('orphaned', result)
+
+    def test_orphan_child_also_retired(self):
+        cats = [
+            _cat(1, 'Links', 'links', 23),
+            _cat(2, 'Blogroll', 'blogroll', 10, parent=1),
+        ]
+        actions = {
+            'links': {'action': 'retire'},
+            'blogroll': {'action': 'retire'},
+        }
+        result = render_category_tree(cats, actions)
+        self.assertNotIn('orphaned', result)
+
+    def test_missing_parent_id(self):
+        cats = [_cat(1, 'Orphan', 'orphan', 5, parent=999)]
+        result = render_category_tree(cats)
+        self.assertIn('Orphan (5)', result)
+        self.assertIn('parent missing', result)
+
+    def test_no_actions_plain_tree(self):
+        cats = [
+            _cat(1, 'Tech', 'tech', 50),
+            _cat(2, 'AI', 'ai', 10, parent=1),
+        ]
+        result = render_category_tree(cats)
+        self.assertIn('Tech (50)', result)
+        self.assertIn('AI (10)', result)
+        self.assertNotIn('\u2715', result)
+        self.assertNotIn('\u2605', result)
+        self.assertNotIn('\u2192 merge', result)
+
+    def test_deterministic_ordering(self):
+        cats = [
+            _cat(3, 'Zebra', 'zebra', 1),
+            _cat(1, 'Alpha', 'alpha', 2),
+            _cat(2, 'Middle', 'middle', 3),
+        ]
+        result1 = render_category_tree(cats)
+        result2 = render_category_tree(cats)
+        self.assertEqual(result1, result2)
+        lines = result1.split('\n')
+        positions = {}
+        for i, line in enumerate(lines):
+            for name in ('Alpha', 'Middle', 'Zebra'):
+                if name in line:
+                    positions[name] = i
+        self.assertLess(positions['Alpha'], positions['Middle'])
+        self.assertLess(positions['Middle'], positions['Zebra'])
+
+    def test_box_drawing_chars_present(self):
+        cats = [
+            _cat(1, 'Parent', 'parent', 10),
+            _cat(2, 'Child A', 'child-a', 5, parent=1),
+            _cat(3, 'Child B', 'child-b', 3, parent=1),
+        ]
+        result = render_category_tree(cats)
+        self.assertIn('\u251c', result)  # ├
+        self.assertIn('\u2514', result)  # └
+        self.assertIn('\u2500', result)  # ─
+
+    def test_create_only_no_existing(self):
+        actions = {'new-cat': {'action': 'create', 'name': 'New Category'}}
+        result = render_category_tree([], actions)
+        self.assertIn('New Category', result)
+        self.assertIn('\u2605 new', result)
+
+    def test_create_parent_not_found(self):
+        cats = [_cat(1, 'Tech', 'tech', 50)]
+        actions = {
+            'sub': {
+                'action': 'create',
+                'name': 'Sub',
+                'parent_slug': 'nonexistent',
+            }
+        }
+        result = render_category_tree(cats, actions)
+        self.assertIn('parent not found', result)
+
+
+class TestDetectOrphans(unittest.TestCase):
+    """Tests for orphan detection logic."""
+
+    def test_no_orphans(self):
+        from helpers import _detect_orphans
+        children_map = {'parent': ['child-a', 'child-b']}
+        actions = {
+            'parent': {'action': 'retire'},
+            'child-a': {'action': 'retire'},
+            'child-b': {'action': 'merge', 'target': 'other'},
+        }
+        orphaned, counts = _detect_orphans(children_map, actions)
+        self.assertEqual(len(orphaned), 0)
+        self.assertEqual(len(counts), 0)
+
+    def test_one_orphan(self):
+        from helpers import _detect_orphans
+        children_map = {'parent': ['child-a', 'child-b']}
+        actions = {'parent': {'action': 'retire'}}
+        orphaned, counts = _detect_orphans(children_map, actions)
+        self.assertEqual(orphaned, {'child-a', 'child-b'})
+        self.assertEqual(counts['parent'], 2)
+
+    def test_merge_causes_orphans(self):
+        from helpers import _detect_orphans
+        children_map = {'source': ['kid']}
+        actions = {'source': {'action': 'merge', 'target': 'dest'}}
+        orphaned, counts = _detect_orphans(children_map, actions)
+        self.assertIn('kid', orphaned)
+        self.assertEqual(counts['source'], 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,6 +14,7 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
 from helpers import (
+    _detect_orphans,
     aggregate_results,
     calculate_batch_size,
     parse_change_log,
@@ -844,11 +845,33 @@ class TestRenderCategoryTree(unittest.TestCase):
         self.assertIn('parent not found', result)
 
 
+    def test_string_ids_handled(self):
+        """WordPress APIs may return term_id and parent as strings."""
+        cats = [
+            {'term_id': '1', 'name': 'Parent', 'slug': 'parent', 'count': 10, 'parent': '0'},
+            {'term_id': '2', 'name': 'Child', 'slug': 'child', 'count': 5, 'parent': '1'},
+        ]
+        result = render_category_tree(cats)
+        self.assertIn('Parent (10)', result)
+        self.assertIn('Child (5)', result)
+        # Child should be nested, not at root with a warning.
+        self.assertNotIn('parent missing', result)
+
+    def test_circular_parent_handled(self):
+        cats = [
+            _cat(1, 'A', 'a', 10, parent=2),
+            _cat(2, 'B', 'b', 5, parent=1),
+        ]
+        result = render_category_tree(cats)
+        self.assertIn('circular', result)
+        self.assertIn('A (10)', result)
+        self.assertIn('B (5)', result)
+
+
 class TestDetectOrphans(unittest.TestCase):
     """Tests for orphan detection logic."""
 
     def test_no_orphans(self):
-        from helpers import _detect_orphans
         children_map = {'parent': ['child-a', 'child-b']}
         actions = {
             'parent': {'action': 'retire'},
@@ -859,8 +882,7 @@ class TestDetectOrphans(unittest.TestCase):
         self.assertEqual(len(orphaned), 0)
         self.assertEqual(len(counts), 0)
 
-    def test_one_orphan(self):
-        from helpers import _detect_orphans
+    def test_all_children_orphaned(self):
         children_map = {'parent': ['child-a', 'child-b']}
         actions = {'parent': {'action': 'retire'}}
         orphaned, counts = _detect_orphans(children_map, actions)
@@ -868,7 +890,6 @@ class TestDetectOrphans(unittest.TestCase):
         self.assertEqual(counts['parent'], 2)
 
     def test_merge_causes_orphans(self):
-        from helpers import _detect_orphans
         children_map = {'source': ['kid']}
         actions = {'source': {'action': 'merge', 'target': 'dest'}}
         orphaned, counts = _detect_orphans(children_map, actions)


### PR DESCRIPTION
Addresses the structural visibility gap from #3: the flat plan table hides parent-child relationships, making it impossible to see when retiring a category would orphan its children.

## What it does

`render_category_tree()` in `lib/helpers.py` takes the exported categories and an actions dict, renders an annotated ASCII tree:

```
Categories
├── Links (23)  ✕ retire  ⚠ 2 children orphaned
│   ├── Blogroll (10)  ⚠ orphaned
│   └── Resources (5)  ⚠ orphaned
├── Personal (89)
├── WordPress (150)
│   ├── Plugins (45)
│   │   ├── Akismet (2)  ✕ retire → plugins
│   │   └── WooCommerce (12)
│   └── Themes (30)
│       └── Full Site Editing (14)  ★ new
└── WP (3)  → merge into wordpress
```

Retire/merge/create actions are annotated inline. Orphan warnings appear when retiring a parent would leave kept children stranded at root level.

## Changes

- `lib/helpers.py`: 5 new functions (~280 lines), pure stdlib Python
- `tests/test_helpers.py`: 21 new tests (18 tree rendering + 3 orphan detection)
- `AGENTS.md`: new "Hierarchy Tree View" section before the flat table, with usage example and actions schema
- `agents/analyze.md`: note about including `parent_slug` for new category suggestions

## Edge cases handled

- Flat sites (all root-level)
- Deep nesting (4+ levels)
- Circular parent references (broken and flagged)
- Missing parent term_id (treated as root, warned)
- Create-only (no existing categories)
- Create with nonexistent parent_slug
- String IDs from WordPress APIs (coerced to int)

All 80 existing + new tests pass.