### PR TITLE
Add WordPress.com API adapter (fixes #1, #2, #3)

### DIFF
--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -1,0 +1,481 @@
+"""
+WordPress.com REST API adapter for Taxonomist.
+
+Provides a tested, safe interface to the WordPress.com / Jetpack API,
+preventing the data integrity bugs documented in issues #1-4:
+- #1: Always uses term_id for operations, never guesses slugs
+- #2: Proper array encoding via wp_urlencode (doseq=True)
+- #3: Always includes parent in update payloads, verifies no duplicates
+- #4: Uses wp_urlencode consistently for all encoding
+
+Matches the WpCliAdapter interface so the orchestrating agent can swap
+between adapters transparently.
+"""
+
+import json
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def wp_urlencode(params):
+    """
+    URL-encode params with proper list handling.
+
+    Uses doseq=True so list values produce repeated keys instead of
+    being stringified. Prevents issue #2 where Python's default
+    urlencode turned ['Tech', 'Science'] into a literal string.
+
+    Args:
+        params: Dict or list of (key, value) tuples.
+
+    Returns:
+        URL-encoded string.
+    """
+    return urllib.parse.urlencode(params, doseq=True)
+
+
+class WpcomApiError(Exception):
+    """Raised when the WordPress.com API returns an error."""
+
+    def __init__(self, status_code, error, message=''):
+        self.status_code = status_code
+        self.error = error
+        super().__init__(f'WP.com API {status_code}: {error} - {message}')
+
+
+class WpcomAdapter:
+    """
+    Adapter for the WordPress.com / Jetpack REST API.
+
+    Implements the same interface as WpCliAdapter so the orchestrating
+    agent can use either adapter transparently.
+    """
+
+    BASE_URL = 'https://public-api.wordpress.com/rest/v1.1'
+
+    def __init__(self, config):
+        """
+        Initialize from a config dict (parsed from config.json).
+
+        Args:
+            config: Dict with 'site_url' and 'connection' containing
+                    'method', 'site_id', and 'access_token'.
+
+        Raises:
+            ValueError: If required config fields are missing.
+        """
+        conn = config.get('connection', {})
+        if conn.get('method') != 'wpcom-api':
+            raise ValueError(
+                f"Expected connection method 'wpcom-api', "
+                f"got '{conn.get('method')}'"
+            )
+        if not conn.get('site_id'):
+            raise ValueError('Missing required field: connection.site_id')
+        if not conn.get('access_token'):
+            raise ValueError('Missing required field: connection.access_token')
+        self.site_id = str(conn['site_id'])
+        self.access_token = conn['access_token']
+        self.site_url = config.get('site_url', '')
+        self._category_cache = None
+
+    # --- HTTP layer ---
+
+    def _request(self, method, path, data=None, params=None):
+        """
+        Make an authenticated request to the WordPress.com API.
+
+        Args:
+            method: HTTP method (GET, POST).
+            path: API path (e.g., '/sites/{id}/categories').
+            data: Dict of form data for POST requests.
+            params: Dict of query parameters.
+
+        Returns:
+            Parsed JSON response as a dict.
+
+        Raises:
+            WpcomApiError: On any API error (including 200 with error field).
+        """
+        url = f'{self.BASE_URL}{path}'
+        if params:
+            url += '?' + wp_urlencode(params)
+
+        body = None
+        if data is not None:
+            body = wp_urlencode(data).encode('utf-8')
+
+        req = urllib.request.Request(url, data=body, method=method)
+        req.add_header('Authorization', f'Bearer {self.access_token}')
+        req.add_header('User-Agent', 'taxonomist/1.0')
+        if body:
+            req.add_header('Content-Type', 'application/x-www-form-urlencoded')
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                resp_body = resp.read().decode('utf-8')
+                result = json.loads(resp_body)
+                if isinstance(result, dict) and 'error' in result:
+                    raise WpcomApiError(
+                        resp.status, result['error'],
+                        result.get('message', ''),
+                    )
+                return result
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode('utf-8', errors='replace')
+            try:
+                err = json.loads(body_text)
+                raise WpcomApiError(
+                    e.code, err.get('error', 'unknown'),
+                    err.get('message', body_text),
+                )
+            except json.JSONDecodeError:
+                raise WpcomApiError(e.code, 'http_error', body_text)
+
+    def _get(self, path, params=None):
+        return self._request('GET', path, params=params)
+
+    def _post(self, path, data=None):
+        return self._request('POST', path, data=data)
+
+    # --- Category cache ---
+
+    def _ensure_category_cache(self):
+        if self._category_cache is None:
+            self._category_cache = self.list_categories()
+        return self._category_cache
+
+    def _invalidate_category_cache(self):
+        self._category_cache = None
+
+    def _get_category_by_id(self, term_id):
+        """
+        Look up a category by term_id.
+
+        Uses cache first, refreshes once on miss to handle
+        recently-created categories.
+
+        Args:
+            term_id: Integer category ID.
+
+        Returns:
+            Category dict, or None if not found.
+        """
+        for cat in self._ensure_category_cache():
+            if cat['ID'] == term_id:
+                return cat
+        # Cache miss -- refresh and retry.
+        self._invalidate_category_cache()
+        for cat in self._ensure_category_cache():
+            if cat['ID'] == term_id:
+                return cat
+        return None
+
+    def _get_category_count(self):
+        """Get the current total number of categories on the site."""
+        resp = self._get(
+            f'/sites/{self.site_id}/categories',
+            params={'number': 0},
+        )
+        return resp.get('found', 0)
+
+    # --- WpCliAdapter-compatible interface ---
+
+    def list_categories(self):
+        """
+        List all categories with metadata.
+
+        Paginates through all categories (1000 per page).
+
+        Returns:
+            List of category dicts with at least: ID, name, slug,
+            description, parent, post_count.
+        """
+        all_categories = []
+        offset = 0
+        page_size = 1000
+        while True:
+            resp = self._get(
+                f'/sites/{self.site_id}/categories',
+                params={'number': page_size, 'offset': offset},
+            )
+            categories = resp.get('categories', [])
+            all_categories.extend(categories)
+            found = resp.get('found', 0)
+            if offset + page_size >= found or not categories:
+                break
+            offset += page_size
+        return all_categories
+
+    def export_posts(self, output_path):
+        """
+        Export all published posts with categories to a JSON file.
+
+        Uses page_handle cursor pagination. Normalizes category hashes
+        to lists.
+
+        Args:
+            output_path: Path to write the JSON file.
+        """
+        all_posts = []
+        page_handle = None
+
+        while True:
+            params = {
+                'number': 100,
+                'status': 'publish',
+                'fields': 'ID,title,content,date,categories',
+            }
+            if page_handle:
+                params['page_handle'] = page_handle
+            resp = self._get(f'/sites/{self.site_id}/posts', params=params)
+            posts = resp.get('posts', [])
+
+            for post in posts:
+                # Normalize categories from {name: {ID: ...}} hash to list.
+                cat_hash = post.get('categories', {})
+                cat_names = list(cat_hash.keys())
+                cat_slugs = [v.get('slug', '') for v in cat_hash.values()]
+
+                content = post.get('content', '')
+                # Strip HTML tags for plain-text analysis.
+                content = re.sub(r'<[^>]+>', '', content)
+                content = re.sub(r'\s+', ' ', content).strip()
+
+                all_posts.append({
+                    'post_id': post['ID'],
+                    'title': post.get('title', ''),
+                    'date': post.get('date', ''),
+                    'content': content,
+                    'categories': cat_names,
+                    'category_slugs': cat_slugs,
+                    'url': post.get('URL', ''),
+                })
+
+            meta = resp.get('meta', {})
+            page_handle = meta.get('next_page')
+            if not page_handle or not posts:
+                break
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(all_posts, f, ensure_ascii=False)
+
+    def set_post_categories(self, post_id, category_ids):
+        """
+        Set categories for a post by term IDs.
+
+        Resolves IDs to names because the WP.com API accepts
+        comma-separated category names, not IDs.
+
+        Args:
+            post_id: Integer post ID.
+            category_ids: List of integer category IDs.
+
+        Raises:
+            WpcomApiError: If any category ID is not found.
+        """
+        categories = self._ensure_category_cache()
+        id_to_name = {c['ID']: c['name'] for c in categories}
+
+        names = []
+        for cid in category_ids:
+            if cid not in id_to_name:
+                raise WpcomApiError(
+                    404, 'not_found', f'Category ID {cid} not found',
+                )
+            names.append(id_to_name[cid])
+
+        self._post(
+            f'/sites/{self.site_id}/posts/{post_id}',
+            data={'categories': ','.join(names)},
+        )
+
+    def create_category(self, name, slug, description=''):
+        """
+        Create a new category.
+
+        Args:
+            name: Display name.
+            slug: URL slug.
+            description: Category description.
+
+        Returns:
+            API response dict with the new category.
+        """
+        data = {'name': name}
+        if slug:
+            data['slug'] = slug
+        if description:
+            data['description'] = description
+
+        result = self._post(f'/sites/{self.site_id}/categories/new', data=data)
+        self._invalidate_category_cache()
+        return result
+
+    def delete_category(self, term_id):
+        """
+        Delete a category by term ID.
+
+        Always resolves the term_id to its slug from live data before
+        deleting. Never guesses slugs. (Prevents issue #1.)
+
+        Args:
+            term_id: Integer category ID.
+
+        Raises:
+            TypeError: If term_id is not an int.
+            WpcomApiError: If category not found.
+        """
+        if not isinstance(term_id, int):
+            raise TypeError(
+                f'term_id must be int, got {type(term_id).__name__}'
+            )
+        cat = self._get_category_by_id(term_id)
+        if cat is None:
+            raise WpcomApiError(
+                404, 'not_found', f'Category {term_id} does not exist',
+            )
+        self._post(
+            f'/sites/{self.site_id}/categories/slug:{cat["slug"]}/delete',
+        )
+        self._invalidate_category_cache()
+
+    # --- Extended interface ---
+
+    def update_category(self, term_id, fields):
+        """
+        Update a category's fields.
+
+        Always includes the current parent in the payload to prevent
+        the WP.com API from silently creating a duplicate term at
+        root level. Verifies term count before and after to detect
+        duplicates. (Prevents issue #3.)
+
+        Args:
+            term_id: Integer category ID.
+            fields: Dict of fields to update (description, name, etc.).
+
+        Returns:
+            API response dict.
+
+        Raises:
+            WpcomApiError: If category not found or duplicate detected.
+        """
+        if not isinstance(term_id, int):
+            raise TypeError(
+                f'term_id must be int, got {type(term_id).__name__}'
+            )
+        current = self._get_category_by_id(term_id)
+        if current is None:
+            raise WpcomApiError(
+                404, 'not_found', f'Category {term_id} not found',
+            )
+
+        # Always include parent to prevent silent duplicate creation.
+        if 'parent' not in fields:
+            fields['parent'] = current.get('parent', 0)
+
+        pre_count = self._get_category_count()
+
+        result = self._post(
+            f'/sites/{self.site_id}/categories/slug:{current["slug"]}',
+            data=fields,
+        )
+
+        post_count = self._get_category_count()
+        if post_count > pre_count:
+            raise WpcomApiError(
+                409, 'duplicate_detected',
+                f'Term count increased from {pre_count} to {post_count} '
+                f'during update of term {term_id}. A duplicate may have '
+                f'been created. Manual inspection required.',
+            )
+
+        self._invalidate_category_cache()
+        return result
+
+    def get_default_category(self):
+        """
+        Get the site's default category.
+
+        Returns:
+            Category dict for the default category.
+
+        Raises:
+            WpcomApiError: If settings or category not found.
+        """
+        resp = self._get(f'/sites/{self.site_id}/settings')
+        settings = resp if 'default_category' in resp else resp.get('settings', {})
+        default_id = settings.get('default_category', 1)
+
+        cat = self._get_category_by_id(default_id)
+        if cat is None:
+            raise WpcomApiError(
+                404, 'not_found',
+                f'Default category {default_id} not found',
+            )
+        return cat
+
+    def backup(self, output_path):
+        """
+        Create a full taxonomy state backup.
+
+        Args:
+            output_path: Path to write the backup JSON file.
+        """
+        categories = self.list_categories()
+
+        # Get post-category mappings.
+        post_categories = []
+        page_handle = None
+        while True:
+            params = {
+                'number': 100,
+                'status': 'publish',
+                'fields': 'ID,title,categories',
+            }
+            if page_handle:
+                params['page_handle'] = page_handle
+            resp = self._get(f'/sites/{self.site_id}/posts', params=params)
+            for post in resp.get('posts', []):
+                cat_hash = post.get('categories', {})
+                post_categories.append({
+                    'post_id': post['ID'],
+                    'post_title': post.get('title', ''),
+                    'category_ids': [v['ID'] for v in cat_hash.values()],
+                    'category_slugs': [v.get('slug', '') for v in cat_hash.values()],
+                })
+            meta = resp.get('meta', {})
+            page_handle = meta.get('next_page')
+            if not page_handle or not resp.get('posts'):
+                break
+
+        # Resolve default category slug.
+        try:
+            default_cat = self.get_default_category()
+            default_slug = default_cat.get('slug', '')
+        except WpcomApiError:
+            default_slug = ''
+
+        backup_data = {
+            'timestamp': time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime()),
+            'site_url': self.site_url,
+            'total_posts': len(post_categories),
+            'total_categories': len(categories),
+            'default_category_slug': default_slug,
+            'categories': [{
+                'term_id': c['ID'],
+                'name': c['name'],
+                'slug': c['slug'],
+                'description': c.get('description', ''),
+                'count': c.get('post_count', 0),
+                'parent': c.get('parent', 0),
+            } for c in categories],
+            'post_categories': post_categories,
+        }
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(backup_data, f, indent=2, ensure_ascii=False)

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -117,7 +117,13 @@ class WpcomAdapter:
         try:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 resp_body = resp.read().decode('utf-8')
-                result = json.loads(resp_body)
+                try:
+                    result = json.loads(resp_body)
+                except json.JSONDecodeError:
+                    raise WpcomApiError(
+                        resp.status, 'invalid_json',
+                        f'Expected JSON, got: {resp_body[:200]}',
+                    )
                 if isinstance(result, dict) and 'error' in result:
                     raise WpcomApiError(
                         resp.status, result['error'],
@@ -125,15 +131,23 @@ class WpcomAdapter:
                     )
                 return result
         except urllib.error.HTTPError as e:
-            body_text = e.read().decode('utf-8', errors='replace')
+            try:
+                body_text = e.read().decode('utf-8', errors='replace')
+            except Exception:
+                body_text = str(e)
             try:
                 err = json.loads(body_text)
                 raise WpcomApiError(
                     e.code, err.get('error', 'unknown'),
                     err.get('message', body_text),
-                )
+                ) from e
             except json.JSONDecodeError:
-                raise WpcomApiError(e.code, 'http_error', body_text)
+                raise WpcomApiError(e.code, 'http_error', body_text) from e
+        except urllib.error.URLError as e:
+            raise WpcomApiError(
+                0, 'connection_error',
+                f'Failed to connect to {url}: {e.reason}',
+            ) from e
 
     def _get(self, path, params=None):
         return self._request('GET', path, params=params)
@@ -236,7 +250,7 @@ class WpcomAdapter:
 
             for post in posts:
                 # Normalize categories from {name: {ID: ...}} hash to list.
-                cat_hash = post.get('categories', {})
+                cat_hash = post.get('categories') or {}
                 cat_names = list(cat_hash.keys())
                 cat_slugs = [v.get('slug', '') for v in cat_hash.values()]
 
@@ -277,16 +291,14 @@ class WpcomAdapter:
         Raises:
             WpcomApiError: If any category ID is not found.
         """
-        categories = self._ensure_category_cache()
-        id_to_name = {c['ID']: c['name'] for c in categories}
-
         names = []
         for cid in category_ids:
-            if cid not in id_to_name:
+            cat = self._get_category_by_id(cid)
+            if cat is None:
                 raise WpcomApiError(
                     404, 'not_found', f'Category ID {cid} not found',
                 )
-            names.append(id_to_name[cid])
+            names.append(cat['name'])
 
         self._post(
             f'/sites/{self.site_id}/posts/{post_id}',
@@ -338,8 +350,9 @@ class WpcomAdapter:
             raise WpcomApiError(
                 404, 'not_found', f'Category {term_id} does not exist',
             )
+        slug = urllib.parse.quote(cat['slug'], safe='')
         self._post(
-            f'/sites/{self.site_id}/categories/slug:{cat["slug"]}/delete',
+            f'/sites/{self.site_id}/categories/slug:{slug}/delete',
         )
         self._invalidate_category_cache()
 
@@ -374,15 +387,19 @@ class WpcomAdapter:
                 404, 'not_found', f'Category {term_id} not found',
             )
 
+        # Copy to avoid mutating the caller's dict.
+        payload = dict(fields)
+
         # Always include parent to prevent silent duplicate creation.
-        if 'parent' not in fields:
-            fields['parent'] = current.get('parent', 0)
+        if 'parent' not in payload:
+            payload['parent'] = current.get('parent', 0)
 
         pre_count = self._get_category_count()
 
+        slug = urllib.parse.quote(current['slug'], safe='')
         result = self._post(
-            f'/sites/{self.site_id}/categories/slug:{current["slug"]}',
-            data=fields,
+            f'/sites/{self.site_id}/categories/slug:{slug}',
+            data=payload,
         )
 
         post_count = self._get_category_count()
@@ -441,7 +458,7 @@ class WpcomAdapter:
                 params['page_handle'] = page_handle
             resp = self._get(f'/sites/{self.site_id}/posts', params=params)
             for post in resp.get('posts', []):
-                cat_hash = post.get('categories', {})
+                cat_hash = post.get('categories') or {}
                 post_categories.append({
                     'post_id': post['ID'],
                     'post_title': post.get('title', ''),
@@ -453,12 +470,16 @@ class WpcomAdapter:
             if not page_handle or not resp.get('posts'):
                 break
 
-        # Resolve default category slug.
+        # Resolve default category slug. Only suppress 404 (category
+        # genuinely missing); all other errors should propagate.
         try:
             default_cat = self.get_default_category()
             default_slug = default_cat.get('slug', '')
-        except WpcomApiError:
-            default_slug = ''
+        except WpcomApiError as e:
+            if e.status_code == 404:
+                default_slug = ''
+            else:
+                raise
 
         backup_data = {
             'timestamp': time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime()),

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -1,0 +1,405 @@
+"""
+Tests for the WordPress.com API adapter.
+
+Uses unittest.mock to patch urllib.request.urlopen so no real HTTP
+requests are made. Verifies issue #1-4 defenses and API interactions.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
+from adapters.wpcom_adapter import WpcomAdapter, WpcomApiError, wp_urlencode
+
+
+VALID_CONFIG = {
+    'site_url': 'https://example.wordpress.com',
+    'connection': {
+        'method': 'wpcom-api',
+        'site_id': '12345',
+        'access_token': 'test-token-xxx',
+    },
+}
+
+
+def _mock_response(data, status=200):
+    """Create a mock urllib response that works as a context manager."""
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = json.dumps(data).encode('utf-8')
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestWpUrlencode(unittest.TestCase):
+    """Tests for the wp_urlencode helper."""
+
+    def test_simple_dict(self):
+        result = wp_urlencode({'name': 'Tech', 'slug': 'tech'})
+        self.assertIn('name=Tech', result)
+        self.assertIn('slug=tech', result)
+
+    def test_list_values_produce_repeated_keys(self):
+        """Issue #2: lists must not be stringified."""
+        result = wp_urlencode({'tags': ['a', 'b']})
+        self.assertEqual(result, 'tags=a&tags=b')
+
+    def test_special_characters_encoded(self):
+        result = wp_urlencode({'name': 'Rock & Roll'})
+        self.assertIn('Rock', result)
+        self.assertIn('%26', result)
+
+
+class TestWpcomAdapterInit(unittest.TestCase):
+    """Tests for adapter initialization and config validation."""
+
+    def test_valid_config(self):
+        adapter = WpcomAdapter(VALID_CONFIG)
+        self.assertEqual(adapter.site_id, '12345')
+        self.assertEqual(adapter.access_token, 'test-token-xxx')
+
+    def test_wrong_method(self):
+        config = {**VALID_CONFIG, 'connection': {
+            'method': 'rest-api', 'site_id': '1', 'access_token': 'x',
+        }}
+        with self.assertRaises(ValueError) as ctx:
+            WpcomAdapter(config)
+        self.assertIn('wpcom-api', str(ctx.exception))
+
+    def test_missing_site_id(self):
+        config = {**VALID_CONFIG, 'connection': {
+            'method': 'wpcom-api', 'access_token': 'x',
+        }}
+        with self.assertRaises(ValueError) as ctx:
+            WpcomAdapter(config)
+        self.assertIn('site_id', str(ctx.exception))
+
+    def test_missing_access_token(self):
+        config = {**VALID_CONFIG, 'connection': {
+            'method': 'wpcom-api', 'site_id': '1',
+        }}
+        with self.assertRaises(ValueError) as ctx:
+            WpcomAdapter(config)
+        self.assertIn('access_token', str(ctx.exception))
+
+
+class TestListCategories(unittest.TestCase):
+    """Tests for listing categories with pagination."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_single_page(self, mock_urlopen):
+        cats = [{'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0}]
+        mock_urlopen.return_value = _mock_response({
+            'found': 1, 'categories': cats,
+        })
+        adapter = WpcomAdapter(VALID_CONFIG)
+        result = adapter.list_categories()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['name'], 'Tech')
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_pagination(self, mock_urlopen):
+        page1 = [{'ID': i, 'name': f'Cat{i}', 'slug': f'cat{i}', 'parent': 0}
+                  for i in range(1000)]
+        page2 = [{'ID': 1000, 'name': 'Last', 'slug': 'last', 'parent': 0}]
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1001, 'categories': page1}),
+            _mock_response({'found': 1001, 'categories': page2}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        result = adapter.list_categories()
+        self.assertEqual(len(result), 1001)
+
+
+class TestDeleteCategory(unittest.TestCase):
+    """Tests for category deletion (issue #1 defenses)."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_rejects_string_input(self, mock_urlopen):
+        """Issue #1: must not accept slug strings."""
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(TypeError) as ctx:
+            adapter.delete_category('my-slug')
+        self.assertIn('int', str(ctx.exception))
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_resolves_by_id(self, mock_urlopen):
+        """Issue #1: resolves slug from live data, not guessing."""
+        cat = {'ID': 42, 'name': 'Test', 'slug': 'test-cat', 'parent': 0}
+        # First call: list_categories for cache. Second: delete.
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1, 'categories': [cat]}),
+            _mock_response({'ID': 42}),  # delete response
+            _mock_response({'found': 0, 'categories': []}),  # cache refresh
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        adapter.delete_category(42)
+
+        # Verify the delete URL contained the correct slug.
+        calls = mock_urlopen.call_args_list
+        delete_call = calls[1]
+        delete_url = delete_call[0][0].full_url
+        self.assertIn('slug:test-cat/delete', delete_url)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_not_found_raises(self, mock_urlopen):
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 0, 'categories': []}),
+            _mock_response({'found': 0, 'categories': []}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError) as ctx:
+            adapter.delete_category(999)
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+class TestUpdateCategory(unittest.TestCase):
+    """Tests for category updates (issue #3 defenses)."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_includes_parent(self, mock_urlopen):
+        """Issue #3: parent always included in update payload."""
+        cat = {'ID': 42, 'name': 'Sub', 'slug': 'sub', 'parent': 5,
+               'description': 'old'}
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1, 'categories': [cat]}),  # cache
+            _mock_response({'found': 1}),  # pre-count
+            _mock_response({'ID': 42, 'slug': 'sub'}),  # update
+            _mock_response({'found': 1}),  # post-count
+            _mock_response({'found': 1, 'categories': [cat]}),  # cache refresh
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        adapter.update_category(42, {'description': 'new'})
+
+        # Find the update POST call and verify parent is in the body.
+        update_call = mock_urlopen.call_args_list[2]
+        req = update_call[0][0]
+        body = req.data.decode('utf-8')
+        self.assertIn('parent=5', body)
+        self.assertIn('description=new', body)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_explicit_parent_used(self, mock_urlopen):
+        """When caller provides parent, use it instead of current."""
+        cat = {'ID': 42, 'name': 'Sub', 'slug': 'sub', 'parent': 5}
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1, 'categories': [cat]}),
+            _mock_response({'found': 1}),
+            _mock_response({'ID': 42}),
+            _mock_response({'found': 1}),
+            _mock_response({'found': 1, 'categories': [cat]}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        adapter.update_category(42, {'parent': 7})
+
+        update_call = mock_urlopen.call_args_list[2]
+        body = update_call[0][0].data.decode('utf-8')
+        self.assertIn('parent=7', body)
+        self.assertNotIn('parent=5', body)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_detects_duplicate(self, mock_urlopen):
+        """Issue #3: raises if term count increases after update."""
+        cat = {'ID': 42, 'name': 'Sub', 'slug': 'sub', 'parent': 5}
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1, 'categories': [cat]}),
+            _mock_response({'found': 10}),  # pre-count: 10
+            _mock_response({'ID': 42}),      # update succeeds
+            _mock_response({'found': 11}),  # post-count: 11 (duplicate!)
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError) as ctx:
+            adapter.update_category(42, {'description': 'new'})
+        self.assertEqual(ctx.exception.status_code, 409)
+        self.assertIn('duplicate', ctx.exception.error)
+
+
+class TestSetPostCategories(unittest.TestCase):
+    """Tests for setting post categories."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_resolves_ids_to_names(self, mock_urlopen):
+        cats = [
+            {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0},
+            {'ID': 2, 'name': 'AI', 'slug': 'ai', 'parent': 0},
+        ]
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 2, 'categories': cats}),
+            _mock_response({'ID': 100}),  # post update
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        adapter.set_post_categories(100, [1, 2])
+
+        post_call = mock_urlopen.call_args_list[1]
+        body = post_call[0][0].data.decode('utf-8')
+        # Should send comma-separated names, not IDs.
+        self.assertIn('categories=Tech', body)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_unknown_id_raises(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({
+            'found': 0, 'categories': [],
+        })
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError) as ctx:
+            adapter.set_post_categories(100, [999])
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+class TestExportPosts(unittest.TestCase):
+    """Tests for post export with category normalization."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_normalizes_category_hash(self, mock_urlopen):
+        """WP.com returns categories as {name: {...}}, not a list."""
+        post = {
+            'ID': 1,
+            'title': 'Test',
+            'content': '<p>Hello <b>world</b></p>',
+            'date': '2024-01-01',
+            'categories': {
+                'Tech': {'ID': 10, 'slug': 'tech'},
+                'AI': {'ID': 20, 'slug': 'ai'},
+            },
+            'URL': 'https://example.com/test',
+        }
+        mock_urlopen.return_value = _mock_response({
+            'found': 1, 'posts': [post], 'meta': {},
+        })
+        adapter = WpcomAdapter(VALID_CONFIG)
+
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.export_posts(output_path)
+            with open(output_path) as f:
+                exported = json.load(f)
+            self.assertEqual(len(exported), 1)
+            self.assertIn('Tech', exported[0]['categories'])
+            self.assertIn('ai', exported[0]['category_slugs'])
+            # HTML should be stripped.
+            self.assertNotIn('<p>', exported[0]['content'])
+            self.assertIn('Hello world', exported[0]['content'])
+        finally:
+            os.unlink(output_path)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_pagination(self, mock_urlopen):
+        post1 = {
+            'ID': 1, 'title': 'P1', 'content': '', 'date': '',
+            'categories': {}, 'URL': '',
+        }
+        post2 = {
+            'ID': 2, 'title': 'P2', 'content': '', 'date': '',
+            'categories': {}, 'URL': '',
+        }
+        mock_urlopen.side_effect = [
+            _mock_response({
+                'found': 2, 'posts': [post1],
+                'meta': {'next_page': 'cursor123'},
+            }),
+            _mock_response({
+                'found': 2, 'posts': [post2], 'meta': {},
+            }),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.export_posts(output_path)
+            with open(output_path) as f:
+                exported = json.load(f)
+            self.assertEqual(len(exported), 2)
+        finally:
+            os.unlink(output_path)
+
+
+class TestErrorHandling(unittest.TestCase):
+    """Tests for API error propagation."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_http_error_raised(self, mock_urlopen):
+        error = urllib.error.HTTPError(
+            'url', 500, 'Server Error', {},
+            MagicMock(read=lambda: b'{"error":"server_error","message":"boom"}'),
+        )
+        mock_urlopen.side_effect = error
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError) as ctx:
+            adapter.list_categories()
+        self.assertEqual(ctx.exception.status_code, 500)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_200_with_error_field(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({
+            'error': 'unauthorized', 'message': 'bad token',
+        })
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError) as ctx:
+            adapter.list_categories()
+        self.assertIn('unauthorized', str(ctx.exception))
+
+
+class TestGetDefaultCategory(unittest.TestCase):
+    """Tests for default category lookup."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_returns_default(self, mock_urlopen):
+        cat = {'ID': 1, 'name': 'Uncategorized', 'slug': 'uncategorized',
+               'parent': 0}
+        mock_urlopen.side_effect = [
+            _mock_response({'default_category': 1}),    # settings
+            _mock_response({'found': 1, 'categories': [cat]}),  # cache
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        result = adapter.get_default_category()
+        self.assertEqual(result['name'], 'Uncategorized')
+
+
+class TestBackup(unittest.TestCase):
+    """Tests for full taxonomy backup."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_writes_backup_json(self, mock_urlopen):
+        cat = {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0,
+               'description': 'Technology', 'post_count': 5}
+        post = {
+            'ID': 100, 'title': 'Test',
+            'categories': {'Tech': {'ID': 1, 'slug': 'tech'}},
+        }
+        mock_urlopen.side_effect = [
+            # list_categories
+            _mock_response({'found': 1, 'categories': [cat]}),
+            # posts pagination
+            _mock_response({'found': 1, 'posts': [post], 'meta': {}}),
+            # get_default_category -> settings
+            _mock_response({'default_category': 1}),
+            # get_default_category -> category cache
+            _mock_response({'found': 1, 'categories': [cat]}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.backup(output_path)
+            with open(output_path) as f:
+                backup = json.load(f)
+            self.assertEqual(backup['total_posts'], 1)
+            self.assertEqual(backup['total_categories'], 1)
+            self.assertEqual(backup['default_category_slug'], 'tech')
+            self.assertEqual(backup['categories'][0]['term_id'], 1)
+            self.assertEqual(backup['post_categories'][0]['post_id'], 100)
+        finally:
+            os.unlink(output_path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -5,6 +5,7 @@ Uses unittest.mock to patch urllib.request.urlopen so no real HTTP
 requests are made. Verifies issue #1-4 defenses and API interactions.
 """
 
+import io
 import json
 import os
 import sys
@@ -326,15 +327,33 @@ class TestErrorHandling(unittest.TestCase):
 
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
     def test_http_error_raised(self, mock_urlopen):
-        error = urllib.error.HTTPError(
-            'url', 500, 'Server Error', {},
-            MagicMock(read=lambda: b'{"error":"server_error","message":"boom"}'),
-        )
+        fp = io.BytesIO(b'{"error":"server_error","message":"boom"}')
+        error = urllib.error.HTTPError('url', 500, 'Server Error', {}, fp)
         mock_urlopen.side_effect = error
         adapter = WpcomAdapter(VALID_CONFIG)
         with self.assertRaises(WpcomApiError) as ctx:
             adapter.list_categories()
         self.assertEqual(ctx.exception.status_code, 500)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_connection_error_raised(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.URLError('Name resolution failed')
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError) as ctx:
+            adapter.list_categories()
+        self.assertEqual(ctx.exception.status_code, 0)
+        self.assertIn('connection_error', ctx.exception.error)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_html_response_raises(self, mock_urlopen):
+        """CDN/Cloudflare returning HTML instead of JSON."""
+        mock_urlopen.return_value = _mock_response('<html>Challenge</html>')
+        # Override mock to return raw bytes
+        mock_urlopen.return_value.read.return_value = b'<html>Challenge</html>'
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError) as ctx:
+            adapter.list_categories()
+        self.assertIn('invalid_json', ctx.exception.error)
 
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
     def test_200_with_error_field(self, mock_urlopen):


### PR DESCRIPTION
Implements a tested adapter for the WordPress.com / Jetpack REST API, filling the gap described in AGENTS.md:

> The intended abstraction is an adapter layer (lib/adapters/) so the same logic can work regardless of connection method. Today the shipped code only includes the WP-CLI adapter.

## Issue defenses

Each of the four open issues traces back to agent-improvised API calls. This adapter codifies the correct behavior:

| Issue | Bug | Defense |
|-------|-----|---------|
| #1 | Guessed slug, deleted wrong category | `delete_category(term_id: int)` resolves slug from live data; raises `TypeError` on string input |
| #2 | `urlencode` stringified list values | `wp_urlencode()` uses `doseq=True`; all encoding goes through it |
| #3 | Update endpoint silently created duplicates | Always includes `parent` in payload; verifies term count before/after; raises on increase |
| #4 | Missing encoding helper | `wp_urlencode()` included in the adapter module |

## What's in the adapter

- Matches `WpCliAdapter` interface: `list_categories`, `export_posts`, `set_post_categories`, `create_category`, `delete_category`
- Extended: `update_category` (with parent preservation), `get_default_category`, `backup`
- Category cache with lazy loading and invalidation after mutations
- Proper pagination: offset-based for categories (1000/page), `page_handle` cursor for posts (100/page)
- Category hash normalization (WP.com returns `{name: {ID: ...}}`, adapter converts to list)
- `set_post_categories` resolves IDs to names (WP.com API takes comma-separated names)
- stdlib only (`urllib.request`), matching existing `wpcom-auth.py` style

## Tests

23 unit tests using `unittest.mock.patch` on `urllib.request.urlopen`:
- Config validation (3 tests)
- Category listing with pagination (2)
- Delete: rejects string input, resolves by ID, not-found error (3)
- Update: includes parent, uses explicit parent, detects duplicates (3)
- Post categories: resolves IDs to names, unknown ID error (2)
- Export: category hash normalization, pagination (2)
- Error handling: HTTP errors, 200-with-error-field (2)
- Default category lookup (1)
- Full backup output (1)

All 23 new + 49 existing tests pass.