### PR TITLE
Document categories_by_id as the safe shape for WP.com post updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,11 @@ Taxonomist is registered as a WordPress.com OAuth2 app (Client ID: `136301`). Us
 Key endpoints:
 - `GET /sites/$site/categories` — list categories (max 1000 per page)
 - `GET /sites/$site/posts?number=100` — list posts (max 100 per page, use `page_handle` for pagination)
-- `POST /sites/$site/posts/$id` — update post categories (`categories` param: comma-separated names)
+- `POST /sites/$site/posts/$id` — update post. For category changes use
+  **v1.2** with `categories_by_id` (array of integer term IDs). This is
+  the only shape that is a true replace and cannot create junk
+  categories. Do not use the `categories` param on this endpoint — see
+  `agents/apply.md` for the silent-failure modes.
 - `POST /sites/$site/categories/new` — create category
 - `POST /sites/$site/categories/slug:$slug` — update category
 - `POST /sites/$site/categories/slug:$slug/delete` — delete category

--- a/agents/apply.md
+++ b/agents/apply.md
@@ -73,11 +73,44 @@ For individual post updates via REST API:
 ```bash
 # REST API
 curl -X POST -u user:pass {url}/wp-json/wp/v2/posts/{id} -d '{"categories":[1,2,3]}'
-# WordPress.com API (uses category names, not IDs)
+
+# WordPress.com API — prefer categories_by_id on v1.2 (see warning below)
 curl -X POST -H 'Authorization: Bearer TOKEN' \
-  --data-urlencode 'categories=Tech,WordPress' \
+  -H 'Content-Type: application/json' \
+  -d '{"categories_by_id": [1, 2, 3]}' \
   'https://public-api.wordpress.com/rest/v1.2/sites/SITE_ID/posts/POST_ID'
 ```
+
+**WordPress.com post category updates** (verified empirically):
+
+For all post category changes, use **v1.2** with the `categories_by_id`
+parameter. It takes an array of integer term IDs, is a true replace,
+and cannot create junk categories regardless of what's in the live
+taxonomy. This is the only sanctioned shape for Taxonomist's analysis
+output.
+
+Do **not** use the `categories` parameter on this endpoint. It is a
+name-based interface with two silent failure modes: numeric values
+become new categories literally named after the number (so a stale ID
+in a "names" list creates a junk category called "1030"), and real
+names drift when a category is renamed upstream of the call.
+
+**Silent-failure modes of `categories_by_id`** (verified empirically):
+
+- **Empty array wipes the post's categories.** Sending
+  `{"categories_by_id": []}` removes every category and WordPress then
+  reassigns the post to the site's default category (e.g. `Uncategorized`).
+  Never send an empty array unless you explicitly intend to clear.
+  Taxonomist should treat an empty `cats` list from analysis as a bug,
+  not a pass-through.
+- **Unknown IDs are silently dropped, not errored.** If you send
+  `{"categories_by_id": [1030, 999999999]}`, the API returns HTTP 200
+  and applies only the IDs that exist (`[1030]` in this example). There
+  is no warning in the response. This means stale IDs — from a renamed
+  category, a deleted category, or a re-exported taxonomy — will quietly
+  disappear. Always validate every ID against the live category list
+  before POSTing, and diff the response's `terms.category` against what
+  you sent to detect drops.
 
 ### Create Category
 ```bash


### PR DESCRIPTION
## Summary

Update the agent instructions for WordPress.com post category updates to use `categories_by_id` on v1.2 instead of category names in the `categories` param. The name-based shape has a silent failure mode (a stale name becomes a new junk category) which is the class of bug Taxonomist exists to prevent.

See the commit for the rule, the silent-failure modes of `categories_by_id`, and the scope rationale.

## How I got here

This came out of reviewing #4, where I looked at `categories_by_id` as an alternative to the name-based `categories` param. In testing, I found the following:

- `categories_by_id` exists on **v1.2** only.
- v1.1 and v1.2 treat numeric values in the `categories` param differently. v1.1 auto-detects them as IDs; v1.2 treats them as names and creates new categories literally named after the number. Any code that opportunistically switches between versions hits exactly the bug class #4 is fixing, from a new angle.
- `categories_by_id` has two silent-failure modes of its own. Empty array wipes the post and falls back to the site default. Unknown IDs are silently dropped with no warning.

For reference:
- https://github.com/Automattic/jetpack/blob/5638ba0b0d10dfb4494c895ea8f4a09e4d54f312/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php#L61
- https://github.com/Automattic/jetpack/blob/5638ba0b0d10dfb4494c895ea8f4a09e4d54f312/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php#L56

## Test plan

All tested live against a real WP.com site:

- [x] v1.2 `categories_by_id: [a, b, c]` — post has exactly those 3 categories
- [x] v1.2 `categories_by_id: [a, b]` — replace semantics (other categories gone)
- [x] v1.2 `categories_by_id: []` — wipes, falls back to `Uncategorized`
- [x] v1.2 `categories_by_id: [valid_id, 999999999]` — stale ID silently dropped, post has only the valid ID
- [x] v1.1 `categories_by_id: [a, b]` — HTTP 400 `invalid_input`
- [x] v1.2 `categories: ["99987", "99988"]` — creates junk categories literally named "99987" and "99988"
- [x] Post restored to its original state, junk categories cleaned up, zero residue
