### PR TITLE
Tell agents how to run lib/ tests and lint before committing

### DIFF
--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -7,4 +7,14 @@ All PHP code in this directory MUST adhere to the [WordPress Coding Standards (W
 - **Yoda Conditions:** Always use Yoda conditions for equality checks against constants, `true`, `false`, or integers (e.g., `if ( true === $my_variable )`)
 - **Sanitization & Escaping:** All untrusted data must be sanitized before processing and escaped before output
 - **SQL Preparation:** All database queries must use `$wpdb->prepare()` to prevent SQL injection
-- **Verification:** Run `phpcs` (`./vendor/bin/phpcs`) if available before presenting changes
+- **Verification:** Run `./vendor/bin/phpcs` (install once with `composer install`) before presenting or committing PHP changes. Auto-fix with `./vendor/bin/phpcbf`.
+
+## Python helpers and tests
+
+`helpers.py` is covered by `tests/test_helpers.py` (Python `unittest`). Run the suite from the repo root before presenting or committing any change to `helpers.py` or other Python code in this directory:
+
+```
+python3 -m unittest discover tests
+```
+
+Bug fixes to helper functions must add a regression test in `tests/test_helpers.py`.


### PR DESCRIPTION
> [!NOTE]
> This is a follow-up to #5. @martinremy Let me know what you think about it!

Now that lib/ has both PHPCS (via .phpcs.xml.dist) and a Python unittest suite for helpers.py, the agents working in this repo should know they exist and run them before presenting or committing changes. Otherwise it's easy to ship a helpers.py tweak that breaks the existing tests, or a PHP change that fails WPCS on the next contributor's machine.

Add the two commands to lib/AGENTS.md (which lib/CLAUDE.md imports), and make the "run before committing" expectation explicit for both. Also note that bug fixes to helpers should come with a regression test in tests/test_helpers.py, to match the wider project guidance.