### PR TITLE
Standardize helper return types and fix AGENTS.md documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,18 @@ Present flagged categories to the user for spot-checking before finalizing the p
 
 ## Analysis Approach
 
-Use `lib/helpers.py` for splitting batches and aggregating results — do not write inline Python scripts for these operations. Use `lib/helpers.aggregate_results()` to combine per-batch results.
+Use `lib/helpers.py` for splitting batches and aggregating results — do not write inline Python scripts for these operations.
+
+**Batching:** Use `write_batches(posts, batch_dir)` as the single entry point for splitting and writing batches. It calculates optimal batch sizes internally and writes numbered JSON files. Do not call `split_into_batches()` before `write_batches()` — `write_batches()` already calculates batch size and splits internally. After writing, call `check_largest_batch(batch_dir)` which returns a 3-tuple `(ok, largest_file, largest_chars)` to verify batches fit under the token limit.
+
+**Aggregating:** Use `aggregate_results(results_dir)` to combine per-batch results. It returns a dict:
+
+```python
+results = aggregate_results('data/results/')
+suggestions = results['suggestions']        # list of suggestion dicts
+category_counts = results['category_counts']  # Counter of slug -> count
+new_category_counts = results['new_category_counts']  # Counter of new cat -> count
+```
 
 Posts are split into adaptively-sized batches (calculated from actual content length to stay under the 10K token Read limit) and analyzed by parallel AI agents. Each agent receives:
 - The full post content (not truncated)

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -146,8 +146,8 @@ def aggregate_results(results_dir):
         results_dir: Directory containing result-NNN.json files.
 
     Returns:
-        Tuple of (all_suggestions, category_counts, new_category_counts)
-        where suggestions is a list of dicts, and counts are Counters.
+        Dict with 'suggestions' (list of dicts), 'category_counts' (Counter),
+        and 'new_category_counts' (Counter).
     """
     suggestions_by_post_id = {}
     unkeyed_suggestions = []
@@ -173,7 +173,11 @@ def aggregate_results(results_dir):
         for cat in post.get('new_cats', []):
             new_cat_counts[cat] += 1
 
-    return all_suggestions, cat_counts, new_cat_counts
+    return {
+        'suggestions': all_suggestions,
+        'category_counts': cat_counts,
+        'new_category_counts': new_cat_counts,
+    }
 
 
 def validate_export(posts):
@@ -181,17 +185,16 @@ def validate_export(posts):
     Validate that an export JSON has the expected structure.
 
     Checks that each post has required fields with correct types.
-    Returns a list of error strings (empty if valid).
 
     Args:
         posts: Parsed JSON list from the export file.
 
     Returns:
-        List of validation error strings.
+        Dict with 'valid' (bool) and 'errors' (list of strings).
     """
     errors = []
     if not isinstance(posts, list):
-        return ['Export must be a JSON array']
+        return {'valid': False, 'errors': ['Export must be a JSON array']}
 
     required_fields = {
         'post_id': int,
@@ -224,7 +227,7 @@ def validate_export(posts):
                     f'"{field}" must contain only strings'
                 )
 
-    return errors
+    return {'valid': not errors, 'errors': errors}
 
 
 def validate_suggestions(suggestions):
@@ -238,11 +241,11 @@ def validate_suggestions(suggestions):
         suggestions: Parsed JSON list from a result file.
 
     Returns:
-        List of validation error strings.
+        Dict with 'valid' (bool) and 'errors' (list of strings).
     """
     errors = []
     if not isinstance(suggestions, list):
-        return ['Suggestions must be a JSON array']
+        return {'valid': False, 'errors': ['Suggestions must be a JSON array']}
 
     for i, entry in enumerate(suggestions):
         if not isinstance(entry, dict):
@@ -264,7 +267,7 @@ def validate_suggestions(suggestions):
             elif any(not isinstance(cat, str) for cat in entry['new_cats']):
                 errors.append(f'Post ID {entry.get("post_id", f"index {i}")}: "new_cats" must contain only strings')
 
-    return errors
+    return {'valid': not errors, 'errors': errors}
 
 
 def validate_backup(backup):
@@ -277,11 +280,11 @@ def validate_backup(backup):
         backup: Parsed JSON dict from a backup file.
 
     Returns:
-        List of validation error strings.
+        Dict with 'valid' (bool) and 'errors' (list of strings).
     """
     errors = []
     if not isinstance(backup, dict):
-        return ['Backup must be a JSON object']
+        return {'valid': False, 'errors': ['Backup must be a JSON object']}
 
     for key in ('timestamp', 'site_url', 'total_posts', 'total_categories', 'default_category_slug', 'categories', 'post_categories'):
         if key not in backup:
@@ -310,7 +313,7 @@ def validate_backup(backup):
                 if isinstance(pc.get('category_slugs'), list) and any(not isinstance(slug, str) for slug in pc['category_slugs']):
                     errors.append(f'Post mapping at index {i}: "category_slugs" must contain only strings')
 
-    return errors
+    return {'valid': not errors, 'errors': errors}
 
 
 def validate_result_ids(results_dir, batch_dir):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -250,7 +250,10 @@ class TestAggregateResults(unittest.TestCase):
             self._write_result(tmpdir, 'result-001.json', [
                 {'post_id': 3, 'cats': ['Tech', 'AI'], 'new_cats': []},
             ])
-            suggestions, cat_counts, new_counts = aggregate_results(tmpdir)
+            result = aggregate_results(tmpdir)
+            suggestions = result['suggestions']
+            cat_counts = result['category_counts']
+            new_counts = result['new_category_counts']
             self.assertEqual(len(suggestions), 3)
             self.assertEqual(cat_counts['Tech'], 2)
             self.assertEqual(cat_counts['Music'], 1)
@@ -259,7 +262,10 @@ class TestAggregateResults(unittest.TestCase):
 
     def test_empty_directory(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            suggestions, cat_counts, new_counts = aggregate_results(tmpdir)
+            result = aggregate_results(tmpdir)
+            suggestions = result['suggestions']
+            cat_counts = result['category_counts']
+            new_counts = result['new_category_counts']
             self.assertEqual(len(suggestions), 0)
             self.assertEqual(len(cat_counts), 0)
 
@@ -270,7 +276,7 @@ class TestAggregateResults(unittest.TestCase):
             ])
             with open(os.path.join(tmpdir, 'notes.txt'), 'w') as f:
                 f.write('ignore me')
-            suggestions, _, _ = aggregate_results(tmpdir)
+            suggestions = aggregate_results(tmpdir)['suggestions']
             self.assertEqual(len(suggestions), 1)
 
     def test_ignores_non_result_json(self):
@@ -281,7 +287,7 @@ class TestAggregateResults(unittest.TestCase):
             self._write_result(tmpdir, 'categories.json', [
                 {'post_id': 99, 'cats': ['Noise'], 'new_cats': []},
             ])
-            suggestions, _, _ = aggregate_results(tmpdir)
+            suggestions = aggregate_results(tmpdir)['suggestions']
             self.assertEqual(len(suggestions), 1)
             self.assertEqual(suggestions[0]['post_id'], 1)
 
@@ -293,7 +299,10 @@ class TestAggregateResults(unittest.TestCase):
             self._write_result(tmpdir, 'result-001.json', [
                 {'post_id': 1, 'cats': ['AI'], 'new_cats': ['ML']},
             ])
-            suggestions, cat_counts, new_counts = aggregate_results(tmpdir)
+            result = aggregate_results(tmpdir)
+            suggestions = result['suggestions']
+            cat_counts = result['category_counts']
+            new_counts = result['new_category_counts']
             self.assertEqual(len(suggestions), 1)
             self.assertEqual(suggestions[0]['cats'], ['AI'])
             self.assertEqual(cat_counts['AI'], 1)
@@ -308,7 +317,7 @@ class TestAggregateResults(unittest.TestCase):
             self._write_result(tmpdir, 'result-000.json', [
                 {'post_id': 1, 'cats': ['A'], 'new_cats': []},
             ])
-            suggestions, _, _ = aggregate_results(tmpdir)
+            suggestions = aggregate_results(tmpdir)['suggestions']
             # result-000 should come first due to sorted() filename order.
             self.assertEqual(suggestions[0]['post_id'], 1)
             self.assertEqual(suggestions[1]['post_id'], 99)
@@ -329,18 +338,22 @@ class TestValidateExport(unittest.TestCase):
                 'url': 'https://example.com/test',
             }
         ]
-        self.assertEqual(validate_export(posts), [])
+        result = validate_export(posts)
+        self.assertTrue(result['valid'])
+        self.assertEqual(result['errors'], [])
 
     def test_not_a_list(self):
-        errors = validate_export({'post_id': 1})
-        self.assertEqual(len(errors), 1)
-        self.assertIn('JSON array', errors[0])
+        result = validate_export({'post_id': 1})
+        self.assertFalse(result['valid'])
+        self.assertEqual(len(result['errors']), 1)
+        self.assertIn('JSON array', result['errors'][0])
 
     def test_missing_field(self):
         posts = [{'post_id': 1, 'title': 'Test'}]
-        errors = validate_export(posts)
-        self.assertTrue(any('missing "date"' in e for e in errors))
-        self.assertTrue(any('missing "content"' in e for e in errors))
+        result = validate_export(posts)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('missing "date"' in e for e in result['errors']))
+        self.assertTrue(any('missing "content"' in e for e in result['errors']))
 
     def test_wrong_type(self):
         posts = [
@@ -352,11 +365,14 @@ class TestValidateExport(unittest.TestCase):
                 'categories': ['Tech'],
             }
         ]
-        errors = validate_export(posts)
-        self.assertTrue(any('"post_id" should be int' in e for e in errors))
+        result = validate_export(posts)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('"post_id" should be int' in e for e in result['errors']))
 
     def test_empty_list_is_valid(self):
-        self.assertEqual(validate_export([]), [])
+        result = validate_export([])
+        self.assertTrue(result['valid'])
+        self.assertEqual(result['errors'], [])
 
     def test_category_lists_must_contain_strings(self):
         posts = [
@@ -370,8 +386,9 @@ class TestValidateExport(unittest.TestCase):
                 'url': 'https://example.com/test',
             }
         ]
-        errors = validate_export(posts)
-        self.assertTrue(any('"categories" must contain only strings' in e for e in errors))
+        result = validate_export(posts)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('"categories" must contain only strings' in e for e in result['errors']))
 
 
 class TestValidateSuggestions(unittest.TestCase):
@@ -382,32 +399,39 @@ class TestValidateSuggestions(unittest.TestCase):
             {'post_id': 1, 'cats': ['Tech'], 'new_cats': []},
             {'post_id': 2, 'cats': ['Music', 'Jazz']},
         ]
-        self.assertEqual(validate_suggestions(data), [])
+        result = validate_suggestions(data)
+        self.assertTrue(result['valid'])
+        self.assertEqual(result['errors'], [])
 
     def test_missing_post_id(self):
         data = [{'cats': ['Tech']}]
-        errors = validate_suggestions(data)
-        self.assertTrue(any('missing "post_id"' in e for e in errors))
+        result = validate_suggestions(data)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('missing "post_id"' in e for e in result['errors']))
 
     def test_missing_cats(self):
         data = [{'post_id': 1}]
-        errors = validate_suggestions(data)
-        self.assertTrue(any('missing "cats"' in e for e in errors))
+        result = validate_suggestions(data)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('missing "cats"' in e for e in result['errors']))
 
     def test_cats_wrong_type(self):
         data = [{'post_id': 1, 'cats': 'Tech'}]
-        errors = validate_suggestions(data)
-        self.assertTrue(any('"cats" must be list' in e for e in errors))
+        result = validate_suggestions(data)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('"cats" must be list' in e for e in result['errors']))
 
     def test_cats_entries_must_be_strings(self):
         data = [{'post_id': 1, 'cats': ['Tech', 7]}]
-        errors = validate_suggestions(data)
-        self.assertTrue(any('"cats" must contain only strings' in e for e in errors))
+        result = validate_suggestions(data)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('"cats" must contain only strings' in e for e in result['errors']))
 
     def test_new_cats_entries_must_be_strings(self):
         data = [{'post_id': 1, 'cats': ['tech'], 'new_cats': ['ml', 7]}]
-        errors = validate_suggestions(data)
-        self.assertTrue(any('"new_cats" must contain only strings' in e for e in errors))
+        result = validate_suggestions(data)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('"new_cats" must contain only strings' in e for e in result['errors']))
 
 
 class TestValidateBackup(unittest.TestCase):
@@ -427,17 +451,21 @@ class TestValidateBackup(unittest.TestCase):
                 {'post_id': 1, 'post_title': 'Test', 'category_ids': [1], 'category_slugs': ['tech']}
             ],
         }
-        self.assertEqual(validate_backup(backup), [])
+        result = validate_backup(backup)
+        self.assertTrue(result['valid'])
+        self.assertEqual(result['errors'], [])
 
     def test_not_a_dict(self):
-        errors = validate_backup([])
-        self.assertIn('Backup must be a JSON object', errors)
+        result = validate_backup([])
+        self.assertFalse(result['valid'])
+        self.assertIn('Backup must be a JSON object', result['errors'])
 
     def test_missing_top_level_keys(self):
-        errors = validate_backup({})
-        self.assertTrue(any('timestamp' in e for e in errors))
-        self.assertTrue(any('categories' in e for e in errors))
-        self.assertTrue(any('default_category_slug' in e for e in errors))
+        result = validate_backup({})
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('timestamp' in e for e in result['errors']))
+        self.assertTrue(any('categories' in e for e in result['errors']))
+        self.assertTrue(any('default_category_slug' in e for e in result['errors']))
 
     def test_missing_category_fields(self):
         backup = {
@@ -446,9 +474,10 @@ class TestValidateBackup(unittest.TestCase):
             'categories': [{'name': 'Tech'}],
             'post_categories': [],
         }
-        errors = validate_backup(backup)
-        self.assertTrue(any('missing "term_id"' in e for e in errors))
-        self.assertTrue(any('missing "slug"' in e for e in errors))
+        result = validate_backup(backup)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('missing "term_id"' in e for e in result['errors']))
+        self.assertTrue(any('missing "slug"' in e for e in result['errors']))
 
     def test_missing_post_mapping_fields(self):
         backup = {
@@ -457,8 +486,9 @@ class TestValidateBackup(unittest.TestCase):
             'categories': [],
             'post_categories': [{'post_id': 1}],
         }
-        errors = validate_backup(backup)
-        self.assertTrue(any('missing "category_slugs"' in e for e in errors))
+        result = validate_backup(backup)
+        self.assertFalse(result['valid'])
+        self.assertTrue(any('missing "category_slugs"' in e for e in result['errors']))
 
 
 class TestParseChangeLog(unittest.TestCase):


### PR DESCRIPTION
## Summary

- `validate_export()`, `validate_suggestions()`, and `validate_backup()` now return `{'valid': bool, 'errors': [...]}` dicts, matching `validate_result_ids()` and `validate_category_slugs()` which already used this pattern
- `aggregate_results()` now returns a dict with `suggestions`, `category_counts`, and `new_category_counts` keys instead of a bare tuple
- AGENTS.md updated to document `write_batches()` as the single batching entry point, `check_largest_batch()` return shape, and `aggregate_results()` dict return

Found during first real end-to-end run on konstantin.obenland.it — agents assumed all validators returned dicts (as documented) but three returned plain lists.

## Test plan
- [x] All 58 helpers tests pass
- [x] All 25 adapter tests pass (no regressions)
- [x] Verified with real exported data (256 posts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)