### PR TITLE
Split Application Password auth into two flows by WP version

### DIFF
--- a/agents/connect.md
+++ b/agents/connect.md
@@ -46,7 +46,7 @@ All configuration should happen through the conversation. Ask for credentials in
        "method": "rest-api",
        "api_url": "https://example.com/wp-json",
        "username": "admin",
-       "app_password": "xxxx xxxx xxxx xxxx"
+       "app_password": "xxxx xxxx xxxx xxxx xxxx xxxx"
      }
    }
    ```
@@ -83,30 +83,61 @@ Test: `wp --path={wp_path} option get blogname`
 
 ### REST API + Application Password
 
-For **self-hosted WordPress** sites (WordPress 5.6+). Uses the browser-based authorize-application flow — same frictionless experience as the WordPress.com OAuth flow.
+For **self-hosted WordPress** sites running WordPress 5.6 or newer with [Application Passwords](https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/) enabled.
 
-**IMPORTANT:** The authorize URL uses wp-admin, which may be at a different path than the site URL. Detect the correct admin URL first (see step 2 above).
+**IMPORTANT:** The authorize URL lives under wp-admin, which may be at a different path than the site URL. Detect the correct admin URL first (see step 2 of the top-level "Steps" section above).
 
-**Automated flow (preferred):**
+This connection method has two flows. **Pick the right one based on the site's WordPress version**, because WordPress 7.0+ unlocks a frictionless one-click flow that older versions cannot use:
 
-1. Start a local HTTP server on port 19823 to capture the callback
+#### Step 1 — Detect the WordPress version
+
+Try these signals in order, stop at the first one that yields a parseable `MAJOR.MINOR.PATCH` string:
+
+1. **Asset query strings on the homepage HTML.** Run `curl -s {site_url}/ | grep -oE 'ver=[0-9]+\.[0-9]+(\.[0-9]+)?' | sort -u` and pick the most common value. WordPress core stylesheets and scripts are loaded with `?ver={core_version}` by default.
+2. **`/feed/` generator element.** Run `curl -s {site_url}/feed/ | grep -oE '<generator>[^<]+</generator>'`. The text usually looks like `https://wordpress.org/?v=6.9.4`.
+3. **`/readme.html`.** Run `curl -s {site_url}/readme.html | grep -oE 'Version [0-9]+\.[0-9]+(\.[0-9]+)?'`. Often deleted on hardened installs.
+4. **`<meta name="generator">` on the homepage.** Often stripped on production sites, so this is the last resort.
+
+If none of those yields a version (hardened sites strip all of them), treat the site as **older than 7.0** and use the manual flow below. That's the universally-safe fallback.
+
+#### Step 2A — WordPress 7.0 or newer: automated loopback flow
+
+This is the preferred path because the user only has to click "Approve" once — no copying or pasting.
+
+1. Start a local HTTP server bound to **`127.0.0.1:19823`** to capture the callback. The agent should write a small Python or Node one-shot server that handles a single GET, parses `user_login` and `password` from the query string, and exits. `0.0.0.0` is acceptable but `127.0.0.1` is safer (loopback only).
 2. Open the user's browser to the authorize URL:
    ```
-   {admin_url}/authorize-application.php?app_name=Taxonomist&success_url=http://localhost:19823/
+   {admin_url}/authorize-application.php?app_name=Taxonomist&success_url=http://127.0.0.1:19823/
    ```
-3. User logs into wp-admin (if needed) and clicks "Yes, I approve of this connection"
-4. WordPress redirects to `http://localhost:19823/?user_login=USERNAME&password=xxxx+xxxx+xxxx+xxxx`
-5. Local server captures the username and app password from the URL parameters
-6. Save to config.json and test
+   Use `open` (macOS), `xdg-open` (Linux), or `start "" "{url}"` (Windows — the empty `""` is required when the URL is quoted).
+3. The user logs into wp-admin if prompted, then clicks **"Yes, I approve of this connection"**.
+4. WordPress redirects the browser to `http://127.0.0.1:19823/?user_login=USERNAME&password=xxxx%20xxxx%20xxxx%20xxxx%20xxxx%20xxxx`. The local server captures both values. The password arrives URL-encoded — spaces can come through as either `%20` or `+` depending on the WordPress version, so URL-decode before saving (Python's `urllib.parse.parse_qs` handles both).
+5. Save to config.json (see schema below) and verify with the test in Step 3.
 
-The `success_url` MUST include the trailing slash. URL-decode the password (spaces come as `+`).
+**Use the literal string `127.0.0.1`, not `localhost`.** WordPress 7.0+ whitelists only the loopback IP literals `127.0.0.1` and `[::1]` (per RFC 8252 §7.3); the hostname `localhost` is intentionally excluded by RFC 8252 §8.3 to avoid DNS resolution and firewall interception risks. A `success_url` of `http://localhost:19823/` is rejected with the same error as any other non-HTTPS URL.
 
-**Fallback:** If the automated flow fails, ask the user to:
-1. Go to **Users → Profile** in wp-admin
-2. Scroll to "Application Passwords", enter "Taxonomist", click "Add New"
-3. Paste the generated password in the chat
+#### Step 2B — WordPress older than 7.0 (or version unknown): no-redirect manual flow
 
-Save everything to config.json (gitignored):
+WordPress versions before 7.0 reject any `http://` `success_url` (unless `WP_ENVIRONMENT_TYPE=local`), so the loopback flow above will fail with *"The URL must be served over a secure connection."* at the Approve step. Instead, use the no-redirect mode of `authorize-application.php` — when no `success_url` is provided, WordPress renders the generated password inline on the wp-admin success page in a readonly text field.
+
+1. Open the user's browser to the authorize URL — **do not include a `success_url` parameter**:
+   ```
+   {admin_url}/authorize-application.php?app_name=Taxonomist
+   ```
+2. The user logs into wp-admin if prompted, then clicks **"Yes, I approve of this connection"**.
+3. WordPress renders the success page with the generated Application Password displayed in a readonly `<input>` field, chunked as `xxxx xxxx xxxx xxxx xxxx xxxx` (24 characters in 6 groups of 4).
+4. Ask the user to paste back **two things**: their WordPress username and the displayed password. Format the prompt clearly:
+   ```
+   username: their-login-username (NOT the display name or email)
+   password: xxxx xxxx xxxx xxxx xxxx xxxx
+   ```
+   The username confusion is a common source of 401s — be explicit that it must be the login slug, not the friendly name.
+5. Save to config.json (see schema below) and verify with the test in Step 3.
+
+#### Step 3 — Save and verify
+
+The config.json schema is the same regardless of which flow ran:
+
 ```json
 {
   "site_url": "https://example.com",
@@ -114,11 +145,52 @@ Save everything to config.json (gitignored):
     "method": "rest-api",
     "api_url": "https://example.com/wp-json",
     "username": "admin",
-    "app_password": "xxxx xxxx xxxx xxxx"
+    "app_password": "xxxx xxxx xxxx xxxx xxxx xxxx"
   }
 }
 ```
-Test by reading credentials from config: `python3 -c "import json; c=json.load(open('config.json'))['connection']; print(c['username'], c['app_password'])"` then use in curl.
+
+Verify the credentials by hitting `/wp-json/wp/v2/users/me?context=edit` with HTTP Basic auth and confirming the response carries the expected user with `edit_posts` and `manage_categories` capabilities. Read the credentials from disk so they don't end up in shell history:
+
+```bash
+python3 -c "
+import json, base64, urllib.request
+c = json.load(open('config.json'))['connection']
+t = base64.b64encode(f\"{c['username']}:{c['app_password']}\".encode()).decode()
+r = urllib.request.urlopen(urllib.request.Request(
+    f\"{c['api_url']}/wp/v2/users/me?context=edit\",
+    headers={'Authorization': f'Basic {t}'}))
+me = json.load(r)
+print('OK:', me['username'], me['roles'], 'edit_posts:', me['capabilities'].get('edit_posts'))
+"
+```
+
+If the verification 401s, the most likely cause is that the user pasted their display name or email instead of their `user_login` slug — ask them to check the **Username** field (not "Name") at `{admin_url}/profile.php`.
+
+#### Failure modes you should anticipate
+
+- **`authorize-application.php` returns "Application passwords are not available."** — The site has Application Passwords disabled site-wide via the `wp_is_application_passwords_available` filter (some hardened/managed hosts do this). There is no programmatic recovery; the user has to enable it server-side or use a different connection method (WP-CLI over SSH if available, or XML-RPC as a last resort).
+- **`authorize-application.php` returns "Application passwords are not available for your account."** — The user's account doesn't have permission. They need an admin to grant it, or they need to log in as an admin user.
+- **`authorize-application.php` returns "This site is protected by HTTP Basic Auth"** — The whole wp-admin is behind a separate auth layer. The user has to authenticate through the basic-auth dialog first; the agent can't proxy this.
+- In all three cases, the agent should explain the failure to the user and offer to fall back to the manual `Users → Profile` path described below.
+
+#### Manual fallback — generate the App Password by hand
+
+If `authorize-application.php` is unreachable (404, blocked, or any of the failure modes above), ask the user to do it manually:
+
+1. Go to **Users → Profile** in wp-admin (`{admin_url}/profile.php`)
+2. Scroll to "Application Passwords", enter `Taxonomist`, click "Add New Application Password"
+3. Copy the generated password and paste it back here along with the WordPress username
+
+#### Why two flows?
+
+Application Password redirect URLs are validated by WordPress core's `wp_is_authorize_application_redirect_url_valid()` in `wp-admin/includes/user.php`. For the entire history of the function, any `http://` `success_url` was rejected unless `wp_get_environment_type() === 'local'` — which is almost never set on staging/production sites. That meant the "automated callback" pattern simply did not work on real WordPress installs.
+
+That changed in [trunk@30eb659](https://github.com/WordPress/wordpress-develop/commit/30eb659) ([Trac #57809](https://core.trac.wordpress.org/ticket/57809), landed 2026-03-24), which added a loopback whitelist for the literal IPs `127.0.0.1` and `[::1]`. The fix is shipping in **WordPress 7.0**. Once that release is out and propagates, the automated flow becomes available — but only on sites running 7.0 or newer.
+
+Until then (and for years afterward, since WordPress sites take a long time to update), every older site has to use the no-redirect manual flow. Hence the two paths and the version check. The version check is being used as a capability check because WordPress core does not expose a way for an unauthenticated client to probe the loopback whitelist directly — `authorize-application.php` enforces authentication before running the URL validator, so we can't trigger the error without already having the credentials we're trying to obtain.
+
+**Security note for the manual flow.** The no-redirect path requires the user to paste the Application Password into the chat transcript, which means the credential ends up wherever your chat history is stored or synced. The automated flow does not have this exposure because the credential travels directly from the browser to a local socket. If the user is concerned, remind them that Application Passwords can be revoked from **Users → Profile** at any time, and that creating a fresh one for each session is cheap.
 
 ### REST API + JWT
 ```json

--- a/agents/connect.md
+++ b/agents/connect.md
@@ -134,6 +134,8 @@ WordPress versions before 7.0 reject any `http://` `success_url` (unless `WP_ENV
    The username confusion is a common source of 401s — be explicit that it must be the login slug, not the friendly name.
 5. Save to config.json (see schema below) and verify with the test in Step 3.
 
+**Security note:** This flow requires the user to paste the Application Password into the chat transcript, which means the credential ends up wherever chat history is stored or synced. The automated flow (Step 2A) avoids this because the credential travels directly from the browser to a local socket. If the user is concerned, remind them that Application Passwords can be revoked from **Users → Profile** at any time, and that creating a fresh one for each session is cheap.
+
 #### Step 3 — Save and verify
 
 The config.json schema is the same regardless of which flow ran:
@@ -181,16 +183,6 @@ If `authorize-application.php` is unreachable (404, blocked, or any of the failu
 1. Go to **Users → Profile** in wp-admin (`{admin_url}/profile.php`)
 2. Scroll to "Application Passwords", enter `Taxonomist`, click "Add New Application Password"
 3. Copy the generated password and paste it back here along with the WordPress username
-
-#### Why two flows?
-
-Application Password redirect URLs are validated by WordPress core's `wp_is_authorize_application_redirect_url_valid()` in `wp-admin/includes/user.php`. For the entire history of the function, any `http://` `success_url` was rejected unless `wp_get_environment_type() === 'local'` — which is almost never set on staging/production sites. That meant the "automated callback" pattern simply did not work on real WordPress installs.
-
-That changed in [trunk@30eb659](https://github.com/WordPress/wordpress-develop/commit/30eb659) ([Trac #57809](https://core.trac.wordpress.org/ticket/57809), landed 2026-03-24), which added a loopback whitelist for the literal IPs `127.0.0.1` and `[::1]`. The fix is shipping in **WordPress 7.0**. Once that release is out and propagates, the automated flow becomes available — but only on sites running 7.0 or newer.
-
-Until then (and for years afterward, since WordPress sites take a long time to update), every older site has to use the no-redirect manual flow. Hence the two paths and the version check. The version check is being used as a capability check because WordPress core does not expose a way for an unauthenticated client to probe the loopback whitelist directly — `authorize-application.php` enforces authentication before running the URL validator, so we can't trigger the error without already having the credentials we're trying to obtain.
-
-**Security note for the manual flow.** The no-redirect path requires the user to paste the Application Password into the chat transcript, which means the credential ends up wherever your chat history is stored or synced. The automated flow does not have this exposure because the credential travels directly from the browser to a local socket. If the user is concerned, remind them that Application Passwords can be revoked from **Users → Profile** at any time, and that creating a fresh one for each session is cheap.
 
 ### REST API + JWT
 ```json


### PR DESCRIPTION
## Background

I was testing Taxonomist on two self-hosted WordPress sites that aren't connected to WordPress.com (one running 6.9.4 and one running 7.1-alpha), and the automated Application Password flow `agents/connect.md` had been documenting failed on both with:

> The URL must be served over a secure connection.

That error comes from WordPress core's `wp_is_authorize_application_redirect_url_valid()`, which was introduced in [r56837](https://core.trac.wordpress.org/changeset/56837) as part of 6.3.2. The original version rejects every `http://` `success_url` that isn't on a site with `WP_ENVIRONMENT_TYPE=local`:

```php
if ( 'http' === $scheme && ! $is_local ) {
    return new WP_Error(
        'invalid_redirect_scheme',
        __( 'The URL must be served over a secure connection.' )
    );
}
```

There's no loopback whitelist in the function at all; both `localhost` and `127.0.0.1` get rejected the same way. So the "spin up a local server on `http://localhost:19823/` and catch the callback" pattern `connect.md` had been documenting never worked on any released WordPress version against a site that wasn't explicitly marked as a local dev install, and `WP_ENVIRONMENT_TYPE=local` is almost never set on production or staging sites.

## What WP 7.0 changes

[#57809](https://core.trac.wordpress.org/ticket/57809) lands in WordPress 7.0 and adds a loopback whitelist for the literal IP strings `127.0.0.1` and `[::1]`, aligned with [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3). The hostname `localhost` is intentionally left out per [§8.3](https://datatracker.ietf.org/doc/html/rfc8252#section-8.3), which flags it as susceptible to DNS resolution poisoning and firewall interception. Once 7.0 ships, the automated flow becomes usable, but only with `127.0.0.1`, and only on 7.0+ sites. Older sites will still reject any `http://` redirect.

## The fix

`agents/connect.md` now documents two Application Password flows and routes the agent between them based on a detected WordPress version:

- **WP 7.0 or newer:** the automated loopback flow. The agent starts a local capture server on `127.0.0.1:19823`, opens `authorize-application.php?app_name=Taxonomist&success_url=http://127.0.0.1:19823/`, and the user clicks Approve. WordPress then redirects the browser to the local server, with the username and generated password in the query string.
- **WP older than 7.0, or version undetermined:** `authorize-application.php` in no-redirect mode. Omit `success_url` entirely; WordPress renders the generated password inline on the wp-admin success page in a readonly text field, and the user pastes it back along with their username. This works on every released WordPress version, all the way back to 5.6 when Application Passwords shipped.

Version detection tries these signals in order: homepage asset `?ver=` query strings, `/feed/` `<generator>`, `/readme.html`, and finally the homepage `<meta name="generator">`. If none of them yields a version (hardened sites strip them all), the agent defaults to the safe manual flow.

I did look for a way to probe the capability directly rather than infer it from the version, but `authorize-application.php` calls `auth_redirect()` before the URL validator runs, so an unauthenticated client can't distinguish "site accepts 127.0.0.1" from "site rejects 127.0.0.1" without already holding the credentials we're trying to obtain. Version detection is the closest available signal, and in this case the WordPress version is effectively the capability; the loopback whitelist ships in a specific core commit in a specific release.

## Also in this PR

A few small doc fixes that turned up while I was rewriting the section, bundled in because they're all in the same neighborhood:

- Fix the example `app_password` chunking in the top-level Steps section. It was shown as 4 chunks of 4, but WordPress core's `chunk_password()` produces 6 chunks of 4 (24 characters total).
- Document the Windows `start "" "{url}"` syntax. The empty quoted title argument is required when the URL is quoted.
- Warn the agent to ask for the login username, not the display name or email, when prompting for the manual-flow paste. That's a common source of confusing 401s.
- Document the three WordPress-side failure modes the agent should anticipate (Application Passwords disabled site-wide, disabled for the user's account, site behind HTTP Basic Auth), and route them to the Users → Profile fallback.
- Note that the manual flow exposes the App Password in the chat transcript while the automated flow does not, and remind users they can revoke passwords at any time from Users → Profile.
- Note that URL-decoded password spaces can arrive as either `%20` or `+` depending on WordPress version (I saw `%20` on the WP 7.1 test site); both decode correctly with `urllib.parse.parse_qs`.

## Testing

I'd recommend testing both flows, one with a stable version of WordPress on a self-hosted site, and another with the Beta tester plugin installed and updated to WP 7.0 Beta.

