### PR TITLE
Add CONTRIBUTING.md with test and lint instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,4 +296,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to run tests and lint locally.
 - The AGENTS.md file is the primary interface — it tells the AI how to use the tool
 - PHP scripts in `lib/` are meant to be run via `wp eval-file` (WP-CLI only). For REST API and WordPress.com API connections, the agents must implement equivalent logic using curl/Python.
 - Keep the adapter layer thin — just translate between connection methods and a common interface
-- Run `./vendor/bin/phpcs` before committing PHP changes and `python3 -m unittest discover tests` before committing Python changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Note: categories in post responses are returned as a hash keyed by name, not an 
 taxonomist/
 ├── AGENTS.md              # AI tool instructions (canonical)
 ├── CLAUDE.md              # Points to AGENTS.md
+├── CONTRIBUTING.md        # How to run tests and lint locally
 ├── config.json            # WordPress connection config (user creates)
 ├── agents/                # AI agent definitions
 │   ├── connect.md         # Detect and configure WordPress access
@@ -289,7 +290,10 @@ If any mismatches are found, fix them immediately and log the corrections. This 
 
 ## Notes for Contributors
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to run tests and lint locally.
+
 - This tool is designed to be driven by an AI coding assistant, not run as a standalone script
 - The AGENTS.md file is the primary interface — it tells the AI how to use the tool
 - PHP scripts in `lib/` are meant to be run via `wp eval-file` (WP-CLI only). For REST API and WordPress.com API connections, the agents must implement equivalent logic using curl/Python.
 - Keep the adapter layer thin — just translate between connection methods and a common interface
+- Run `./vendor/bin/phpcs` before committing PHP changes and `python3 -m unittest discover tests` before committing Python changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Taxonomist
+
+## Prerequisites
+
+- PHP 7.4+
+- Python 3.8+
+- [Composer](https://getcomposer.org/)
+
+## Setup
+
+```bash
+composer install
+```
+
+This installs [WordPress Coding Standards (WPCS)](https://github.com/WordPress/WordPress-Coding-Standards) for PHP linting.
+
+## Running Tests
+
+### Python tests
+
+The helper functions and WordPress.com adapter are covered by a unittest suite in `tests/`:
+
+```bash
+python3 -m unittest discover tests
+```
+
+Bug fixes must include a regression test in `tests/`.
+
+## Linting
+
+### PHP (WPCS)
+
+Lint all PHP files in `lib/`:
+
+```bash
+./vendor/bin/phpcs
+```
+
+Auto-fix what can be fixed automatically:
+
+```bash
+./vendor/bin/phpcbf
+```
+
+The ruleset is defined in `.phpcs.xml.dist`.
+
+## Before You Commit
+
+Run both checks:
+
+```bash
+./vendor/bin/phpcs
+python3 -m unittest discover tests
+```
+
+Both must pass before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Every change is logged and reversible. Full backup before any modifications. Dry
 
 Posts are exported locally and split into batches. Parallel AI agents analyze the full content of every post and suggest optimal categories. Results are aggregated, reviewed with you, and applied via WP-CLI or REST API.
 
+## Contributing
+
+Contributions are welcome! Whether it's a bug fix, a new adapter, or improved analysis logic, we'd love your help. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to set up your environment and run tests and lint locally before submitting changes.
+
 ## Thanks
 
 Thanks to [Arun Sathiya](https://www.arun.blog/), Hannah Swain Løvik, Joash Rajin, and Rich Tabor for help testing.


### PR DESCRIPTION
## Summary

Contributors don't currently have a single place explaining how to validate their changes locally. This adds that.

- New `CONTRIBUTING.md` covering prerequisites, setup (`composer install`), Python tests (`python3 -m unittest discover tests`), and PHP linting (`./vendor/bin/phpcs` / `phpcbf`)
- README now has a Contributing section inviting contributions and linking to the new file
- AGENTS.md references CONTRIBUTING.md in "Notes for Contributors" and lists the lint/test commands so AI-assisted contributors pick them up too

This extends #12, which adds similar guidance to `lib/AGENTS.md` for AI agents. This PR builds on that by giving human contributors the same info in a more traditional place.

## Test plan

- [ ] Verify `composer install && ./vendor/bin/phpcs` works from a fresh clone
- [ ] Verify `python3 -m unittest discover tests` passes
- [ ] Check that links in README and AGENTS.md resolve correctly