### PR TITLE
GitHub actions: run phpcs, ruff, and the Python tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: astral-sh/ruff-action@v3
         with:
-          python-version: '3.12'
-          cache: pip
-
-       - uses: astral-sh/ruff-action@v3
-         with:
-           src: lib/ tests/
+          src: lib/ tests/
 
   python-tests:
     name: python-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,9 @@ jobs:
           python-version: '3.12'
           cache: pip
 
-      - name: Install ruff
-        run: pip install ruff
-
-      - name: Run ruff
-        run: ruff check --output-format=github lib/ tests/
+       - uses: astral-sh/ruff-action@v3
+         with:
+           src: lib/ tests/
 
   python-tests:
     name: python-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  phpcs:
+    name: phpcs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+          coverage: none
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run phpcs
+        run: ./vendor/bin/phpcs
+
+  ruff:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff
+        run: ruff check --output-format=github lib/ tests/
+
+  python-tests:
+    name: python-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run unittest discover
+        run: python -m unittest discover -s tests -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   phpcs:

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -13,7 +13,6 @@ import json
 import os
 from collections import Counter
 
-
 # Token limit for agent Read tool. Override via TAXONOMIST_MAX_BATCH_TOKENS env var.
 # Default 8000 gives headroom under the typical 10K limit. The export agent
 # should call probe_read_limit() to discover the actual limit at runtime and
@@ -218,7 +217,8 @@ def validate_export(posts):
                 )
 
         for field in ('categories', 'category_slugs'):
-            if isinstance(post.get(field), list) and any(not isinstance(value, str) for value in post[field]):
+            values = post.get(field)
+            if isinstance(values, list) and any(not isinstance(v, str) for v in values):
                 errors.append(
                     f'Post ID {post.get("post_id", f"index {i}")}: '
                     f'"{field}" must contain only strings'
@@ -248,21 +248,22 @@ def validate_suggestions(suggestions):
         if not isinstance(entry, dict):
             errors.append(f'Entry at index {i} is not an object')
             continue
+        label = f'Post ID {entry.get("post_id", f"index {i}")}'
         if 'post_id' not in entry:
             errors.append(f'Entry at index {i}: missing "post_id"')
         elif not isinstance(entry['post_id'], int):
             errors.append(f'Entry at index {i}: "post_id" must be int')
         if 'cats' not in entry:
-            errors.append(f'Post ID {entry.get("post_id", f"index {i}")}: missing "cats"')
+            errors.append(f'{label}: missing "cats"')
         elif not isinstance(entry['cats'], list):
-            errors.append(f'Post ID {entry.get("post_id", f"index {i}")}: "cats" must be list')
+            errors.append(f'{label}: "cats" must be list')
         elif any(not isinstance(cat, str) for cat in entry['cats']):
-            errors.append(f'Post ID {entry.get("post_id", f"index {i}")}: "cats" must contain only strings')
+            errors.append(f'{label}: "cats" must contain only strings')
         if 'new_cats' in entry:
             if not isinstance(entry['new_cats'], list):
-                errors.append(f'Post ID {entry.get("post_id", f"index {i}")}: "new_cats" must be list')
+                errors.append(f'{label}: "new_cats" must be list')
             elif any(not isinstance(cat, str) for cat in entry['new_cats']):
-                errors.append(f'Post ID {entry.get("post_id", f"index {i}")}: "new_cats" must contain only strings')
+                errors.append(f'{label}: "new_cats" must contain only strings')
 
     return errors
 
@@ -283,7 +284,16 @@ def validate_backup(backup):
     if not isinstance(backup, dict):
         return ['Backup must be a JSON object']
 
-    for key in ('timestamp', 'site_url', 'total_posts', 'total_categories', 'default_category_slug', 'categories', 'post_categories'):
+    required_keys = (
+        'timestamp',
+        'site_url',
+        'total_posts',
+        'total_categories',
+        'default_category_slug',
+        'categories',
+        'post_categories',
+    )
+    for key in required_keys:
         if key not in backup:
             errors.append(f'Missing required key: "{key}"')
 
@@ -307,8 +317,12 @@ def validate_backup(backup):
                 for field in ('post_id', 'category_slugs'):
                     if field not in pc:
                         errors.append(f'Post mapping at index {i}: missing "{field}"')
-                if isinstance(pc.get('category_slugs'), list) and any(not isinstance(slug, str) for slug in pc['category_slugs']):
-                    errors.append(f'Post mapping at index {i}: "category_slugs" must contain only strings')
+                slugs = pc.get('category_slugs')
+                if isinstance(slugs, list) and any(not isinstance(s, str) for s in slugs):
+                    errors.append(
+                        f'Post mapping at index {i}: '
+                        f'"category_slugs" must contain only strings'
+                    )
 
     return errors
 

--- a/lib/wpcom-auth.py
+++ b/lib/wpcom-auth.py
@@ -113,7 +113,8 @@ def main():
                     self.end_headers()
                     self.wfile.write(
                         b"<html><body><h2>Authorization failed</h2>"
-                        b"<p>The OAuth state did not match. Return to the terminal and try again.</p>"
+                        b"<p>The OAuth state did not match. "
+                        b"Return to the terminal and try again.</p>"
                         b"</body></html>"
                     )
                     return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -101,7 +101,7 @@ class TestCheckLargestBatch(unittest.TestCase):
         path = os.path.join(self.test_dir, 'batch-000.json')
         with open(path, 'w') as f:
             f.write('x' * 100)
-        
+
         ok, largest, size = check_largest_batch(self.test_dir, max_chars=150)
         self.assertTrue(ok)
         self.assertEqual(largest, 'batch-000.json')
@@ -113,7 +113,7 @@ class TestCheckLargestBatch(unittest.TestCase):
             path = os.path.join(self.test_dir, f'batch-{i:03d}.json')
             with open(path, 'w') as f:
                 f.write('x' * size)
-        
+
         ok, largest, size = check_largest_batch(self.test_dir, max_chars=200)
         self.assertTrue(ok)
         self.assertEqual(largest, 'batch-001.json')
@@ -124,7 +124,7 @@ class TestCheckLargestBatch(unittest.TestCase):
         path = os.path.join(self.test_dir, 'batch-000.json')
         with open(path, 'w') as f:
             f.write('x' * 300)
-        
+
         ok, largest, size = check_largest_batch(self.test_dir, max_chars=200)
         self.assertFalse(ok)
         self.assertEqual(largest, 'batch-000.json')
@@ -137,10 +137,11 @@ class TestMaxBatchTokensEnv(unittest.TestCase):
     def test_env_override(self):
         # We need to reload helpers to pick up the env var change
         # since it's set at the module level.
-        import os
         import importlib
+        import os
+
         import helpers
-        
+
         original_val = os.environ.get('TAXONOMIST_MAX_BATCH_TOKENS')
         try:
             os.environ['TAXONOMIST_MAX_BATCH_TOKENS'] = '5000'
@@ -421,10 +422,22 @@ class TestValidateBackup(unittest.TestCase):
             'total_categories': 10,
             'default_category_slug': 'uncategorized',
             'categories': [
-                {'term_id': 1, 'name': 'Tech', 'slug': 'tech', 'description': '', 'count': 5, 'parent': 0}
+                {
+                    'term_id': 1,
+                    'name': 'Tech',
+                    'slug': 'tech',
+                    'description': '',
+                    'count': 5,
+                    'parent': 0,
+                }
             ],
             'post_categories': [
-                {'post_id': 1, 'post_title': 'Test', 'category_ids': [1], 'category_slugs': ['tech']}
+                {
+                    'post_id': 1,
+                    'post_title': 'Test',
+                    'category_ids': [1],
+                    'category_slugs': ['tech'],
+                }
             ],
         }
         self.assertEqual(validate_backup(backup), [])
@@ -466,9 +479,18 @@ class TestParseChangeLog(unittest.TestCase):
 
     def test_parses_log(self):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.tsv', delete=False, newline='') as f:
-            f.write("timestamp\taction\tpost_id\tpost_title\told_categories\tnew_categories\tcats_added\tcats_removed\n")
-            f.write("2024-01-01 00:00:00\tSET_CATS\t123\tTest Post\tAsides\tTech|AI\tTech|AI\tAsides\n")
-            f.write("2024-01-01 00:00:01\tSET_CATS\t456\tOther Post\tAsides\tMusic\tMusic\tAsides\n")
+            f.write(
+                "timestamp\taction\tpost_id\tpost_title\told_categories\t"
+                "new_categories\tcats_added\tcats_removed\n"
+            )
+            f.write(
+                "2024-01-01 00:00:00\tSET_CATS\t123\tTest Post\tAsides\t"
+                "Tech|AI\tTech|AI\tAsides\n"
+            )
+            f.write(
+                "2024-01-01 00:00:01\tSET_CATS\t456\tOther Post\tAsides\t"
+                "Music\tMusic\tAsides\n"
+            )
             path = f.name
 
         try:

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -17,7 +17,6 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
 from adapters.wpcom_adapter import WpcomAdapter, WpcomApiError, wp_urlencode
 
-
 VALID_CONFIG = {
     'site_url': 'https://example.wordpress.com',
     'connection': {


### PR DESCRIPTION
Today there's no automated gate on pull requests; a reviewer has to remember to run phpcs, ruff, and the unittest suite by hand. This PR adds a GitHub Actions workflow that runs all three in parallel on every PR, so regressions get caught mechanically and human review can focus on intent rather than style.

## What's in here

- A new `.github/workflows/ci.yml` with three jobs: `phpcs`, `ruff`, and `python-tests`. They run in parallel with no dependency chain, so a phpcs failure doesn't hide Python feedback and vice versa.
- The workflow runs on every PR.
- A minimal `pyproject.toml` at the repo root so local `ruff check` produces the same output as CI. Python 3.12 target, 100-character lines, pycodestyle + pyflakes + import sorting.
- A cleanup pass on the 19 ruff violations that surfaced the first time I ran the new config. All mechanical: import ordering, trailing whitespace on blank lines, and a handful of over-long lines wrapped by extracting a local or splitting a string literal. No behavior changes; the unittest suite still passes 83/83.

## Of note

- PHP 8.4 and Python 3.12, single versions only. phpcs is style-only so runtime version doesn't matter, and we can always add a matrix later if the need shows up.
- Ruff runs with `--output-format=github`, which gets us inline PR annotations for free.
- phpcs output stays in the Actions log. I considered piping it through cs2pr for inline annotations too, but that's a dependency I'd rather not introduce for a project this size.
- Trigger is `pull_request` only, no `push: main`. Once branch protection is on, the merge commit on main came from a PR that already went green, so running CI a second time there just burns minutes.
- No PHP test job yet; we don't have any PHP tests to run. That's a separate ticket.

## Follow-up

We could then marking `phpcs`, `ruff`, and `python-tests` as required status checks in this repo's branch protection settings.

## How I tested

I tested the workflow with a PR in my fork of this repo, and it was successful.
