### PR TITLE
Add ability to revert for WP.com sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,16 +143,20 @@ taxonomist/
 
 ## Change Logging
 
-Every operation that modifies the site is logged to `data/logs/`. Each log file is a TSV with columns:
+Every operation that modifies the site is logged to `data/logs/`. Each apply run produces:
 
-```
-timestamp  action  post_id  post_title  old_categories  new_categories  cats_added  cats_removed
-```
-
-Log files:
-- `backup-{timestamp}.json` — Complete pre-change state (post→category mappings)
-- `changes-{timestamp}.tsv` — Every individual change made
-- `terms-deleted-{timestamp}.tsv` — Deleted category terms with their original data
+- `data/backups/backup-{timestamp}.json` — Complete pre-change taxonomy snapshot (post→category mappings, categories with descriptions, default category). Always written before any mutation.
+- `data/logs/changes-{timestamp}.tsv` — Per-post category assignment changes. Schema:
+  ```
+  timestamp  action  post_id  post_title  old_categories  new_categories  cats_added  cats_removed
+  ```
+  Action is `SET_CATS`. Written by `lib/apply-changes.php` (WP-CLI) and by `WpcomAdapter.set_post_categories()` when logging is enabled.
+- `data/logs/terms-{timestamp}.tsv` — Term-level operations (create / delete / update / set-default). Schema:
+  ```
+  timestamp  action  term_id  slug  field  old_value  new_value
+  ```
+  Actions are `CREATE_CAT`, `DELETE_CAT`, `UPDATE_CAT` (one row per changed field), and `SET_DEFAULT`. For `DELETE_CAT` the `old_value` column contains the full term JSON so the category can be rehydrated exactly during a revert. Written by the wpcom adapter; for WP-CLI sites the existing `restore.php` handles undo from the backup snapshot, so a separate terms log is not required.
+- `data/logs/restore-{timestamp}.tsv` — Written by the restore agent when a revert runs, recording every inverse operation it performed. Lets a revert itself be audited.
 
 ### Reverting Changes
 
@@ -161,7 +165,15 @@ To undo all changes from a session:
 "Revert the changes from {timestamp}"
 ```
 
-The AI will read the log and backup files and restore the exact previous state.
+The restore agent (`agents/restore.md`) will:
+1. Load the backup and the change/term logs.
+2. Detect the connection method from `config.json`.
+3. Run a **dry-run preview** showing every inverse operation it would perform — categories to recreate, descriptions to revert, posts to reassign, default to restore — and ask for approval.
+4. Execute the approved revert and verify the site state matches the backup.
+
+Two modes are supported. **Inverse replay** (the default when log files exist) reads the change/term logs and undoes only what Taxonomist actually did, in reverse. **Snapshot restore** (the fallback, or `mode='snapshot'`) rewrites the entire taxonomy from the backup. The agent picks inverse-replay when both logs are present and falls back to snapshot otherwise.
+
+For `wp-cli-*` connections the agent uses `lib/restore.php`. For `wpcom-api` it uses `WpcomAdapter.restore()`. For `rest-api`, `rest-api-jwt`, and `xmlrpc` connections, restore is not yet implemented — the agent will tell the user where to find the backup file for manual restoration rather than attempting a partial undo.
 
 ## Result Validation
 

--- a/agents/apply.md
+++ b/agents/apply.md
@@ -15,19 +15,42 @@ Read `config.json` for connection details. Read the change plan from the file pa
 ## Logging
 
 BEFORE making any changes, create:
-- `data/backups/pre-apply-{timestamp}.json` — snapshot of every post's current categories
+- `data/backups/backup-{timestamp}.json` — full pre-apply taxonomy snapshot. For WP-CLI: `wp eval-file lib/backup.php`. For WordPress.com: `WpcomAdapter.backup('data/backups/backup-{timestamp}.json')`.
 
-For bulk post category changes applied through `lib/apply-changes.php`, write to `data/logs/changes-{timestamp}.tsv` with the schema the script actually emits:
-```
-timestamp	action	post_id	post_title	old_categories	new_categories	cats_added	cats_removed
+Two TSV logs are written during the apply run. They live next to the backup and the restore agent reads them to do a precise inverse replay:
+
+- `data/logs/changes-{timestamp}.tsv` — per-post category changes. Schema:
+  ```
+  timestamp	action	post_id	post_title	old_categories	new_categories	cats_added	cats_removed
+  ```
+  Action: `SET_CATS`.
+- `data/logs/terms-{timestamp}.tsv` — term operations. Schema:
+  ```
+  timestamp	action	term_id	slug	field	old_value	new_value
+  ```
+  Actions: `CREATE_CAT`, `DELETE_CAT`, `UPDATE_CAT` (one row per changed field), `SET_DEFAULT`. For `DELETE_CAT`, `old_value` is the full pre-delete term encoded as JSON so the category can be rehydrated exactly during revert.
+
+**For WordPress.com sites you MUST use the `WpcomAdapter` for every term and post mutation, with logging enabled.** The adapter writes both TSV logs automatically — do not perform create/update/delete/post-assignment via raw curl, because curl calls bypass the logger and break revert. Enable logging once at the start of the run:
+
+```python
+import json, sys
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'lib/adapters')
+from wpcom_adapter import WpcomAdapter
+
+with open('config.json') as f:
+    config = json.load(f)
+adapter = WpcomAdapter(config)
+ts = '{timestamp}'  # the same timestamp you used for the backup file
+adapter.set_logging(
+    changes_log_path=f'data/logs/changes-{ts}.tsv',
+    terms_log_path=f'data/logs/terms-{ts}.tsv',
+)
 ```
 
-`lib/apply-changes.php` currently logs `SET_CATS` rows for post-level category changes only. If you create, delete, merge, or update terms outside that script, record those operations in a separate session log before you apply them so they can still be audited and reversed.
+Then call `adapter.create_category(...)`, `adapter.update_category(...)`, `adapter.delete_category(...)`, `adapter.set_post_categories(...)`, `adapter.set_default_category(...)` and the rows are written for you.
 
-For deleted terms, also write to `data/logs/terms-deleted-{timestamp}.tsv`:
-```
-timestamp	term_id	name	slug	description	count	merged_into
-```
+For WP-CLI sites, `lib/apply-changes.php` writes `changes-{timestamp}.tsv` directly (post-level changes only). The terms log is not required for WP-CLI — the existing `lib/restore.php` reverts WP-CLI runs from the backup snapshot.
 
 ## Safety & Shell Escaping
 
@@ -51,9 +74,9 @@ curl -X POST -u user:pass {url}/wp-json/wp/v2/categories -d '{"name":"...","slug
 Pattern: get posts in source → add target to each → remove source from each → delete source term.
 Log every post touched.
 
-### Set Post Categories (bulk)
+### Set Post Categories (bulk) — WP-CLI
 
-**You MUST use `lib/apply-changes.php` for bulk category updates. Do not write inline PHP loops — the script handles paginated processing, secure TSV logging, slug resolution, and taxonomy drift detection.**
+**You MUST use `lib/apply-changes.php` for bulk category updates on WP-CLI sites. Do not write inline PHP loops — the script handles paginated processing, secure TSV logging, slug resolution, and taxonomy drift detection.**
 
 ```bash
 # Preview what would change (default mode)
@@ -69,58 +92,65 @@ TAXONOMIST_REMOVE_CATS=asides \
 wp eval-file lib/apply-changes.php
 ```
 
-For individual post updates via REST API:
-```bash
-# REST API
-curl -X POST -u user:pass {url}/wp-json/wp/v2/posts/{id} -d '{"categories":[1,2,3]}'
-# WordPress.com API (uses category names, not IDs)
-curl -X POST -H 'Authorization: Bearer TOKEN' \
-  --data-urlencode 'categories=Tech,WordPress' \
-  'https://public-api.wordpress.com/rest/v1.2/sites/SITE_ID/posts/POST_ID'
+### Set Post Categories (bulk) — WordPress.com
+
+**You MUST use `WpcomAdapter.set_post_categories()` for WordPress.com sites.** Do not call the WP.com posts endpoint via raw curl — that bypasses the changes-{timestamp}.tsv log and breaks revert.
+
+```python
+adapter.set_post_categories(
+    post_id=123,
+    category_ids=[5, 7],
+    old_category_ids=[5, 9],   # required for the inverse-replay log
+    post_title='Hello world',  # display only
+)
 ```
+
+Always pass `old_category_ids` from your in-memory export so the adapter doesn't have to make an extra fetch per post. The adapter writes one `SET_CATS` row to the changes log automatically.
 
 ### Create Category
 ```bash
 # WP-CLI
 wp term create category "Name" --slug=slug --description="..."
-# WordPress.com API
-curl -X POST -H 'Authorization: Bearer TOKEN' \
-  --data-urlencode 'name=Name' --data-urlencode 'description=...' \
-  'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/categories/new'
+```
+```python
+# WordPress.com — adapter logs CREATE_CAT to terms-{timestamp}.tsv
+adapter.create_category(name='Name', slug='slug', description='...')
 ```
 
 ### Update Category
-```bash
-# WordPress.com API
-curl -X POST -H 'Authorization: Bearer TOKEN' \
-  --data-urlencode 'description=New description' \
-  'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/categories/slug:SLUG'
+```python
+# WordPress.com — adapter logs one UPDATE_CAT row per changed field
+adapter.update_category(term_id=49, fields={'description': 'New description'})
 ```
 
 ### Delete Category
-NEVER delete a category without first reassigning its posts. Log the deleted term's full data.
+NEVER delete a category without first reassigning its posts.
 
 **CRITICAL: Check the default category first.** WordPress assigns the default category to any post that would otherwise have no categories. Deleting it causes problems.
 
 ```bash
 # WP-CLI — get the default category ID
 wp option get default_category
-# REST API
-curl -s -u user:pass {url}/wp-json/wp/v2/settings | python3 -c "import sys,json; print(json.load(sys.stdin).get('default_category'))"
-# WordPress.com API
-curl -s -H 'Authorization: Bearer TOKEN' 'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/settings' | python3 -c "import sys,json; print(json.load(sys.stdin).get('settings',{}).get('default_category'))"
+```
+```python
+# WordPress.com
+default = adapter.get_default_category()
+print(default['ID'], default['slug'])
 ```
 
 If you need to retire the default category, change the default first:
 ```bash
 wp option update default_category NEW_TERM_ID
 ```
+```python
+# WordPress.com — adapter logs SET_DEFAULT to terms-{timestamp}.tsv
+adapter.set_default_category(NEW_TERM_ID)
+```
 
 Never delete the default category without changing the setting first.
-```bash
-# WordPress.com API
-curl -X POST -H 'Authorization: Bearer TOKEN' \
-  'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/categories/slug:SLUG/delete'
+```python
+# WordPress.com — adapter logs DELETE_CAT (with the full pre-delete term as JSON) to terms-{timestamp}.tsv
+adapter.delete_category(term_id=88)
 ```
 
 ## Execution Order
@@ -141,9 +171,13 @@ curl -X POST -H 'Authorization: Bearer TOKEN' \
 
 ## Revert
 
-**You MUST use `lib/restore.php` for reverting changes. Do not write inline PHP loops.** The restore script handles recreating deleted terms, resolving parent hierarchy, fixing name collisions, restoring the default category setting, and flushing caches.
+Reverting is handled by a dedicated agent: see `agents/restore.md`. Do not write your own undo logic.
 
-```bash
-# Perform a full authoritative restore from a backup file
-TAXONOMIST_BACKUP=/path/to/data/backups/backup-{timestamp}.json wp eval-file lib/restore.php
-```
+The restore agent dispatches by connection method:
+
+- **WP-CLI** sites use `lib/restore.php` (full snapshot replay):
+  ```bash
+  TAXONOMIST_BACKUP=/path/to/data/backups/backup-{timestamp}.json wp eval-file lib/restore.php
+  ```
+- **WordPress.com** sites use `WpcomAdapter.restore()`, which prefers inverse-replay of `changes-{timestamp}.tsv` + `terms-{timestamp}.tsv` (only undoes what the apply run actually did) and falls back to a snapshot replay from `backup-{timestamp}.json` when the logs are missing. Both modes support `dry_run=True` so the restore agent can preview every operation before executing.
+- **REST API / JWT / XML-RPC** are not yet supported by the restore agent. The pre-apply backup file is still written for these connections so a manual restore is possible.

--- a/agents/restore.md
+++ b/agents/restore.md
@@ -81,27 +81,42 @@ If the dry run had errors, surface them in the question description so the user 
 
 ### Step 4 — Execute the revert
 
-Re-run with `dry_run=False` and the same arguments. Stream progress as you go.
+Re-run with `dry_run=False` and the same arguments. **The adapter raises `PartialRestoreError` if any operation fails**, so wrap the call:
 
 ```python
-result = adapter.restore(
-    backup_path=f'data/backups/backup-{ts}.json',
-    changes_log_path=f'data/logs/changes-{ts}.tsv',
-    terms_log_path=f'data/logs/terms-{ts}.tsv',
-    mode='auto',
-    dry_run=False,
-)
+from wpcom_adapter import PartialRestoreError
+
+try:
+    result = adapter.restore(
+        backup_path=f'data/backups/backup-{ts}.json',
+        changes_log_path=f'data/logs/changes-{ts}.tsv',
+        terms_log_path=f'data/logs/terms-{ts}.tsv',
+        mode='auto',
+        dry_run=False,
+    )
+    # Clean restore — all operations succeeded.
+except PartialRestoreError as e:
+    result = e.result
+    # Some operations failed. result['partial'] is True and
+    # result['errors'] lists what went wrong. Always surface these
+    # to the user — a half-done revert is worse than no revert.
 ```
+
+The result dict always includes `partial: bool`. When `partial` is True the site is in a mixed state and the user needs to decide next steps (retry, force snapshot mode, or inspect manually).
 
 Write `data/logs/restore-{revert-timestamp}.tsv` recording each executed operation, so the revert itself is auditable and (in principle) reversible.
 
 ### Step 5 — Verify
 
-After the revert returns, sample-check the live site to confirm the state matches the backup:
+The adapter verifies each category mutation via read-back (comparing live state to intended state after each write). Any drift between "the API returned 200" and "the category actually has the right value" is surfaced as a `verification` key on the operation dict. Check for these:
 
-1. Re-pull a handful of posts that were touched (look at `result['operations']` for `set_post_categories` entries) and confirm their categories match the backup.
-2. Re-pull each category that was recreated/renamed/described and confirm the field matches.
-3. Confirm the default category setting.
+```python
+for op in result['operations']:
+    if 'verification' in op:
+        print(f"DRIFT: {op['kind']} — {op['verification']}")
+```
+
+Additionally, sample-check a handful of reverted posts from the live site to confirm their categories match the backup (the adapter does not do per-post read-back to avoid doubling API calls for large sites).
 
 If any mismatches are found, report them. The user may want to fall back to a forced snapshot restore: re-run with `mode='snapshot'`.
 

--- a/agents/restore.md
+++ b/agents/restore.md
@@ -1,0 +1,135 @@
+---
+name: restore
+description: Revert a Taxonomist run. Previews every change before writing, then replays the inverse operations against the live site.
+tools: Bash, Read, Write
+model: sonnet
+maxTurns: 30
+---
+
+You revert a previous Taxonomist apply run. Your #1 priority is **never silently leave the site half-restored** — preview every operation, ask for approval, then execute and verify.
+
+## Locate the run
+
+The user will identify a run by its `{timestamp}`. Find these files in the project's `data/` directory:
+
+- `data/backups/backup-{timestamp}.json` — the pre-apply taxonomy snapshot. **Required.** If missing, abort with a clear message: there is no safe undo without the backup.
+- `data/logs/changes-{timestamp}.tsv` — per-post category changes. Optional but strongly preferred.
+- `data/logs/terms-{timestamp}.tsv` — term operations (create/delete/update/set-default). Optional but strongly preferred.
+
+If the user did not specify a timestamp, list the most recent backups in `data/backups/` and ask which one to revert via `AskUserQuestion`.
+
+## Detect the connection method
+
+Read `config.json` and dispatch on `connection.method`:
+
+| Method | Action |
+|---|---|
+| `wp-cli-ssh`, `wp-cli-local` | Use the existing PHP restore script (see "WP-CLI restore" below). |
+| `wpcom-api` | Use `lib/adapters/wpcom_adapter.WpcomAdapter.restore()` (see "WordPress.com restore" below). |
+| `rest-api`, `rest-api-jwt`, `xmlrpc` | **Not yet supported.** Print a clear message: "Restore for connection method `{method}` is not yet implemented. The full pre-apply snapshot is at `data/backups/backup-{timestamp}.json` — you can use that file to restore manually, or wait for adapter support." Then exit. Do NOT attempt a partial restore via curl. |
+
+## WordPress.com restore (the new path)
+
+The adapter exposes a single entry point: `WpcomAdapter.restore(backup_path, changes_log_path, terms_log_path, mode, dry_run)`. Always run dry-run first.
+
+### Step 1 — Dry-run preview
+
+```python
+import json, sys
+sys.path.insert(0, 'lib')
+sys.path.insert(0, 'lib/adapters')
+from wpcom_adapter import WpcomAdapter
+
+with open('config.json') as f:
+    config = json.load(f)
+adapter = WpcomAdapter(config)
+
+ts = '{timestamp}'
+result = adapter.restore(
+    backup_path=f'data/backups/backup-{ts}.json',
+    changes_log_path=f'data/logs/changes-{ts}.tsv',
+    terms_log_path=f'data/logs/terms-{ts}.tsv',
+    mode='auto',  # logs if present, snapshot fallback
+    dry_run=True,
+)
+print(json.dumps(result, indent=2))
+```
+
+`result['mode']` will be `'logs'` (preferred — surgical inverse replay) or `'snapshot'` (fallback — rewrites the entire taxonomy from the backup). `result['operations']` is the ordered list of inverse operations the live run would perform. `result['errors']` lists any rows that couldn't be inverted.
+
+### Step 2 — Render the preview
+
+Group `operations` by `kind` and present a single readable table. Highlight:
+
+- Categories that would be **recreated** (`create_category`)
+- Categories that would be **deleted** (`delete_category`) — these are categories Taxonomist created during the apply run
+- Category descriptions / names that would be **reverted** (`update_category`)
+- Posts whose categories would be **reassigned** (`set_post_categories`) — show count, plus a few examples
+- The **default category** restoration (`set_default_category`)
+- Anything in `errors` — show all of them, even if there are many. Errors must be visible before approval.
+
+Tell the user which mode was selected and why. If `mode == 'snapshot'`, explicitly note this is the heavy-handed path: it will rewrite every post and category to match the backup, even rows the apply run didn't touch.
+
+### Step 3 — Get approval
+
+Use `AskUserQuestion` with two options:
+
+1. **Proceed with revert (Recommended)** — execute the dry-run plan exactly as previewed.
+2. **Cancel** — do nothing.
+
+If the dry run had errors, surface them in the question description so the user is making an informed choice. Do not proceed silently if errors exist.
+
+### Step 4 — Execute the revert
+
+Re-run with `dry_run=False` and the same arguments. Stream progress as you go.
+
+```python
+result = adapter.restore(
+    backup_path=f'data/backups/backup-{ts}.json',
+    changes_log_path=f'data/logs/changes-{ts}.tsv',
+    terms_log_path=f'data/logs/terms-{ts}.tsv',
+    mode='auto',
+    dry_run=False,
+)
+```
+
+Write `data/logs/restore-{revert-timestamp}.tsv` recording each executed operation, so the revert itself is auditable and (in principle) reversible.
+
+### Step 5 — Verify
+
+After the revert returns, sample-check the live site to confirm the state matches the backup:
+
+1. Re-pull a handful of posts that were touched (look at `result['operations']` for `set_post_categories` entries) and confirm their categories match the backup.
+2. Re-pull each category that was recreated/renamed/described and confirm the field matches.
+3. Confirm the default category setting.
+
+If any mismatches are found, report them. The user may want to fall back to a forced snapshot restore: re-run with `mode='snapshot'`.
+
+## WP-CLI restore (existing path, unchanged)
+
+For `wp-cli-ssh` / `wp-cli-local` use the proven PHP path:
+
+```bash
+TAXONOMIST_BACKUP=/path/to/data/backups/backup-{timestamp}.json wp eval-file lib/restore.php
+```
+
+Show the user what command you're about to run and ask for confirmation first. There is no separate dry-run for the PHP path today; the existing script is authoritative.
+
+## Forcing snapshot mode
+
+If the user explicitly asks for "full restore" or "wipe and reapply", or if the change logs are missing/corrupted, pass `mode='snapshot'`. This walks every category and every post in the backup and forces them back to the snapshot state. It's slower and touches everything, but it works without logs.
+
+```python
+result = adapter.restore(
+    backup_path=f'data/backups/backup-{ts}.json',
+    mode='snapshot',
+    dry_run=True,
+)
+```
+
+## Hard rules
+
+- Never write to the site before showing the dry-run and getting explicit approval.
+- Never silently skip errors. If an inverse operation fails, surface it.
+- Never invent a restore for an unsupported adapter — print the manual-restore message and stop.
+- Always confirm the connection method before dispatching. If `config.json` is missing, refuse to proceed.

--- a/agents/restore.md
+++ b/agents/restore.md
@@ -86,6 +86,7 @@ Re-run with `dry_run=False` and the same arguments. **The adapter raises `Partia
 ```python
 from wpcom_adapter import PartialRestoreError
 
+revert_ts = '{revert-timestamp}'  # use current time, not the original apply timestamp
 try:
     result = adapter.restore(
         backup_path=f'data/backups/backup-{ts}.json',
@@ -93,6 +94,7 @@ try:
         terms_log_path=f'data/logs/terms-{ts}.tsv',
         mode='auto',
         dry_run=False,
+        restore_log_path=f'data/logs/restore-{revert_ts}.tsv',
     )
     # Clean restore — all operations succeeded.
 except PartialRestoreError as e:
@@ -104,7 +106,7 @@ except PartialRestoreError as e:
 
 The result dict always includes `partial: bool`. When `partial` is True the site is in a mixed state and the user needs to decide next steps (retry, force snapshot mode, or inspect manually).
 
-Write `data/logs/restore-{revert-timestamp}.tsv` recording each executed operation, so the revert itself is auditable and (in principle) reversible.
+The `restore_log_path` argument is **not optional in spirit** — always pass it. The adapter streams each operation to this TSV as it executes, so even if the process crashes mid-revert, there's a durable on-disk record of what actually ran. Do not write the restore log from agent code — the adapter enforces it.
 
 ### Step 5 — Verify
 

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -1392,8 +1392,11 @@ class WpcomAdapter:
             backup_slugs = {c.get('slug', '') for c in backup_cats}
             try:
                 current_default = self.get_default_category()
-            except WpcomApiError:
-                current_default = None
+            except WpcomApiError as e:
+                if e.status_code == 404:
+                    current_default = None
+                else:
+                    raise
             for live in live_cats:
                 slug = live.get('slug', '')
                 if not slug or slug in backup_slugs:

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -1389,7 +1389,30 @@ class WpcomAdapter:
             # Step 5: delete categories that exist live but not in the
             # backup (created after the snapshot). Skip the default to
             # avoid orphaning posts.
+            #
+            # Warning: the backup only contains published posts, so
+            # drafts/private/pending/future posts are invisible here.
+            # Deleting a category that a non-published post still
+            # references will cause WordPress to silently reassign that
+            # post to the default category.
             backup_slugs = {c.get('slug', '') for c in backup_cats}
+            extra_slugs = [
+                c['slug'] for c in live_cats
+                if c.get('slug') and c['slug'] not in backup_slugs
+            ]
+            if extra_slugs:
+                operations.append({
+                    'kind': 'warning',
+                    'message': (
+                        f'Deleting {len(extra_slugs)} category(ies) not '
+                        'in the backup. The backup only covers published '
+                        'posts — any drafts, private, pending, or future-'
+                        'dated posts that reference these categories will '
+                        'be silently reassigned to the default category '
+                        'by WordPress.'
+                    ),
+                    'categories': extra_slugs,
+                })
             try:
                 current_default = self.get_default_category()
             except WpcomApiError as e:

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -1114,13 +1114,13 @@ class WpcomAdapter:
                             int(result['ID']),
                             {'parent': int(live_parent['ID'])},
                         )
-                    except WpcomApiError:
-                        op['note'] = (
+                    except WpcomApiError as e:
+                        op['verification'] = (
                             f'parent {backup_parent_id} found but could '
-                            'not be set'
+                            f'not be set: {e}'
                         )
                 else:
-                    op['note'] = (
+                    op['verification'] = (
                         f'parent {backup_parent_id} not found on live site'
                     )
             return op

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -50,6 +50,24 @@ class WpcomApiError(Exception):
         super().__init__(f'WP.com API {status_code}: {error} - {message}')
 
 
+class PartialRestoreError(Exception):
+    """Raised when a restore completes but some operations failed.
+
+    Callers who only check for exceptions will see this instead of
+    silently receiving a success-shaped dict from a half-done revert.
+    The full result dict (with operations, errors, and partial=True)
+    is attached for inspection.
+    """
+
+    def __init__(self, result):
+        self.result = result
+        n = len(result.get('errors', []))
+        super().__init__(
+            f'Restore completed with {n} error(s) — site may be in a '
+            'partially reverted state. Inspect result.errors for details.'
+        )
+
+
 # Log row action types. Defined as constants so a typo in either the
 # writer or the reader becomes a NameError instead of a silent no-op.
 ACTION_SET_CATS = 'SET_CATS'
@@ -228,6 +246,34 @@ class WpcomAdapter:
         if not slug:
             return None
         return self._find_category(lambda c: c.get('slug') == slug)
+
+    def _verify_category_state(self, slug, expected_fields):
+        """
+        Read back a category and verify it matches expected state.
+
+        Returns an error string if verification fails, None if OK.
+        Used after mutations in the restore path to catch silent drift.
+        """
+        self._invalidate_category_cache()
+        cat = self._lookup_category_by_slug(slug)
+        if cat is None:
+            return f'verification: category slug "{slug}" not found after write'
+        mismatches = []
+        for field, expected in expected_fields.items():
+            actual = cat.get(field)
+            if str(actual) != str(expected):
+                mismatches.append(f'{field}: expected {expected!r}, got {actual!r}')
+        if mismatches:
+            return f'verification on "{slug}": {"; ".join(mismatches)}'
+        return None
+
+    def _verify_category_absent(self, slug):
+        """Verify a category no longer exists after deletion."""
+        self._invalidate_category_cache()
+        cat = self._lookup_category_by_slug(slug)
+        if cat is not None:
+            return f'verification: category "{slug}" still exists after delete'
+        return None
 
     def _lookup_category_by_name(self, name):
         if not name:
@@ -817,38 +863,46 @@ class WpcomAdapter:
                     'restore mode=logs requires at least one of '
                     'changes_log_path or terms_log_path to exist'
                 )
-            return self.restore_from_logs(change_rows, term_rows, dry_run=dry_run)
-
-        if mode == MODE_AUTO:
+            result = self.restore_from_logs(
+                change_rows, term_rows, dry_run=dry_run,
+            )
+        elif mode == MODE_AUTO and have_both_logs:
             # Require BOTH logs for an inverse replay. A partial replay
             # (e.g., post assignments only) would leave orphaned created/
             # deleted categories behind — worse than a full snapshot undo.
-            if have_both_logs:
-                return self.restore_from_logs(
-                    change_rows, term_rows, dry_run=dry_run,
-                )
-            # Fall through to snapshot. If only one log exists, include
-            # a note so the agent can surface it to the user.
-
-        if not backup_path:
-            raise ValueError(
-                'restore: no logs and no backup_path provided — nothing to do'
-                if mode == MODE_AUTO
-                else 'restore mode=snapshot requires backup_path'
+            result = self.restore_from_logs(
+                change_rows, term_rows, dry_run=dry_run,
             )
-        with open(backup_path, encoding='utf-8') as f:
-            result = self.restore_from_snapshot(json.load(f), dry_run=dry_run)
-        if mode == MODE_AUTO and have_any_log and not have_both_logs:
-            present = 'terms' if term_rows else 'changes'
-            missing = 'changes' if term_rows else 'terms'
-            result['errors'].append({
-                'op': None,
-                'error': (
-                    f'Only the {present} log was found ({missing} log is '
-                    'missing). Fell back to full snapshot restore to avoid '
-                    'a partial revert.'
-                ),
-            })
+        else:
+            # Snapshot fallback.
+            if not backup_path:
+                raise ValueError(
+                    'restore: no logs and no backup_path provided — '
+                    'nothing to do'
+                    if mode == MODE_AUTO
+                    else 'restore mode=snapshot requires backup_path'
+                )
+            with open(backup_path, encoding='utf-8') as f:
+                result = self.restore_from_snapshot(
+                    json.load(f), dry_run=dry_run,
+                )
+            if mode == MODE_AUTO and have_any_log and not have_both_logs:
+                present = 'terms' if term_rows else 'changes'
+                missing = 'changes' if term_rows else 'terms'
+                result['errors'].append({
+                    'op': None,
+                    'error': (
+                        f'Only the {present} log was found ({missing} '
+                        'log is missing). Fell back to full snapshot '
+                        'restore to avoid a partial revert.'
+                    ),
+                })
+
+        # Surface partial failures loudly. A caller who only checks for
+        # exceptions must not believe a half-done revert succeeded.
+        result['partial'] = bool(result['errors'])
+        if result['partial'] and not dry_run:
+            raise PartialRestoreError(result)
         return result
 
     def restore_from_logs(self, change_rows, term_rows, dry_run=False):
@@ -905,6 +959,7 @@ class WpcomAdapter:
             'mode': MODE_LOGS,
             'operations': operations,
             'errors': errors,
+            'partial': bool(errors),
             'dry_run': dry_run,
         }
 
@@ -955,6 +1010,9 @@ class WpcomAdapter:
             if dry_run:
                 return op
             self.delete_category(int(cat['ID']))
+            err = self._verify_category_absent(slug)
+            if err:
+                op['verification'] = err
             return op
 
         if source == SOURCE_TERM and action == ACTION_DELETE_CAT:
@@ -984,6 +1042,12 @@ class WpcomAdapter:
                 snapshot.get('slug', ''),
                 snapshot.get('description', ''),
             )
+            err = self._verify_category_state(
+                snapshot.get('slug', ''),
+                {'name': snapshot.get('name', '')},
+            )
+            if err:
+                op['verification'] = err
             # Restore parent-child relationship. The snapshot stores the
             # backup's term_id as parent, which may not match the live ID
             # (e.g., if the parent was also deleted and recreated). Resolve
@@ -1044,6 +1108,12 @@ class WpcomAdapter:
                     'category not found on live site',
                 )
             self.update_category(int(cat['ID']), {field: old_value})
+            # For slug changes, verify against the restored slug; for
+            # other fields, the slug column in the row is still valid.
+            verify_slug = old_value if field == 'slug' else slug
+            err = self._verify_category_state(verify_slug, {field: old_value})
+            if err:
+                op['verification'] = err
             return op
 
         if source == SOURCE_TERM and action == ACTION_SET_DEFAULT:
@@ -1089,8 +1159,8 @@ class WpcomAdapter:
         operations = []
         errors = []
 
-        def execute(op, fn, *args):
-            """Run an op and append it to operations / errors. Closure."""
+        def execute(op, fn, *args, verify=None):
+            """Run an op, verify the result, append to operations/errors."""
             operations.append(op)
             if dry_run:
                 return
@@ -1098,6 +1168,11 @@ class WpcomAdapter:
                 fn(*args)
             except WpcomApiError as e:
                 errors.append({'op': op, 'error': str(e)})
+                return
+            if verify:
+                err = verify()
+                if err:
+                    errors.append({'op': op, 'error': err})
 
         with self._logging_suspended():
             backup_cats = backup_data.get('categories', [])
@@ -1126,6 +1201,9 @@ class WpcomAdapter:
                          'description': cat.get('description', '')},
                         self.create_category,
                         cat.get('name', ''), slug, cat.get('description', ''),
+                        verify=lambda s=slug: self._verify_category_state(
+                            s, {'slug': s},
+                        ),
                     )
                     cats_mutated = True
                 elif live.get('name') != cat.get('name'):
@@ -1134,6 +1212,9 @@ class WpcomAdapter:
                          'field': 'name', 'restore_to': cat.get('name', '')},
                         self.update_category,
                         int(live['ID']), {'name': cat.get('name', '')},
+                        verify=lambda s=slug, n=cat.get('name', ''): (
+                            self._verify_category_state(s, {'name': n})
+                        ),
                     )
                     cats_mutated = True
 
@@ -1167,6 +1248,9 @@ class WpcomAdapter:
                          'field': 'parent', 'restore_to': desired_parent},
                         self.update_category,
                         int(live['ID']), {'parent': desired_parent},
+                        verify=lambda s=slug, p=desired_parent: (
+                            self._verify_category_state(s, {'parent': p})
+                        ),
                     )
 
             # Step 2b: reconcile descriptions.
@@ -1182,6 +1266,9 @@ class WpcomAdapter:
                          'field': 'description', 'restore_to': desired_desc},
                         self.update_category,
                         int(live['ID']), {'description': desired_desc},
+                        verify=lambda s=slug, d=desired_desc: (
+                            self._verify_category_state(s, {'description': d})
+                        ),
                     )
 
             # Step 3: restore post category assignments. Pre-collect any
@@ -1256,12 +1343,14 @@ class WpcomAdapter:
                     {'kind': 'delete_category', 'slug': slug},
                     self.delete_category,
                     int(live['ID']),
+                    verify=lambda s=slug: self._verify_category_absent(s),
                 )
 
         return {
             'mode': MODE_SNAPSHOT,
             'operations': operations,
             'errors': errors,
+            'partial': bool(errors),
             'dry_run': dry_run,
         }
 

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -738,6 +738,9 @@ class WpcomAdapter:
         'timestamp', 'action', 'term_id', 'slug',
         'field', 'old_value', 'new_value',
     )
+    RESTORE_LOG_HEADER = (
+        'timestamp', 'kind', 'detail', 'status', 'error',
+    )
 
     def set_logging(self, changes_log_path=None, terms_log_path=None):
         """
@@ -831,10 +834,28 @@ class WpcomAdapter:
             ),
         )
 
+    def _log_restore_op(self, path, op, status='ok', error=''):
+        """Stream a single restore operation to the audit TSV."""
+        ts = self._log_timestamp()
+        kind = op.get('kind', '?')
+        # Build a short detail string from whatever the op dict has.
+        detail_parts = []
+        for key in ('slug', 'post_id', 'restore_slug', 'field', 'restore_to'):
+            val = op.get(key)
+            if val is not None:
+                detail_parts.append(f'{key}={val}')
+        detail = '; '.join(detail_parts) or ''
+        self._append_tsv(
+            path,
+            self.RESTORE_LOG_HEADER,
+            (ts, kind, detail, status, str(error) if error else ''),
+        )
+
     # --- Restore ---
 
     def restore(self, backup_path=None, changes_log_path=None,
-                terms_log_path=None, mode=MODE_AUTO, dry_run=False):
+                terms_log_path=None, mode=MODE_AUTO, dry_run=False,
+                restore_log_path=None):
         """
         Revert a Taxonomist run.
 
@@ -848,14 +869,23 @@ class WpcomAdapter:
                 MODE_LOGS (force log replay; error if no logs), or
                 MODE_SNAPSHOT (force full backup replay).
             dry_run: If True, return planned operations without writing.
+            restore_log_path: Path for the restore audit TSV. Each
+                executed operation is streamed here as it completes so
+                a crash leaves a durable record of what actually ran.
+                Ignored during dry-run. Pass this instead of writing the
+                log from agent code — the adapter enforces it so an
+                agent that forgets the step can't produce a revert with
+                no audit trail.
 
         Returns:
-            Dict with keys: mode, operations, errors, dry_run.
+            Dict with keys: mode, operations, errors, partial, dry_run.
         """
         term_rows = _try_parse_log(terms_log_path, _parse_terms_tsv)
         change_rows = _try_parse_log(changes_log_path, _parse_changes_tsv)
         have_both_logs = bool(term_rows) and bool(change_rows)
         have_any_log = bool(term_rows) or bool(change_rows)
+
+        rlp = restore_log_path if not dry_run else None
 
         if mode == MODE_LOGS:
             if not have_any_log:
@@ -865,6 +895,7 @@ class WpcomAdapter:
                 )
             result = self.restore_from_logs(
                 change_rows, term_rows, dry_run=dry_run,
+                restore_log_path=rlp,
             )
         elif mode == MODE_AUTO and have_both_logs:
             # Require BOTH logs for an inverse replay. A partial replay
@@ -872,6 +903,7 @@ class WpcomAdapter:
             # deleted categories behind — worse than a full snapshot undo.
             result = self.restore_from_logs(
                 change_rows, term_rows, dry_run=dry_run,
+                restore_log_path=rlp,
             )
         else:
             # Snapshot fallback.
@@ -885,6 +917,7 @@ class WpcomAdapter:
             with open(backup_path, encoding='utf-8') as f:
                 result = self.restore_from_snapshot(
                     json.load(f), dry_run=dry_run,
+                    restore_log_path=rlp,
                 )
             if mode == MODE_AUTO and have_any_log and not have_both_logs:
                 present = 'terms' if term_rows else 'changes'
@@ -905,7 +938,8 @@ class WpcomAdapter:
             raise PartialRestoreError(result)
         return result
 
-    def restore_from_logs(self, change_rows, term_rows, dry_run=False):
+    def restore_from_logs(self, change_rows, term_rows, dry_run=False,
+                          restore_log_path=None):
         """
         Inverse-replay change and term log rows in reverse-time order.
 
@@ -948,12 +982,23 @@ class WpcomAdapter:
                     op = self._invert_op(source, row, dry_run, id_to_slug)
                     if op is not None:
                         operations.append(op)
+                        if restore_log_path and not dry_run:
+                            self._log_restore_op(
+                                restore_log_path, op, status='ok',
+                            )
                 except (WpcomApiError, ValueError, KeyError, TypeError) as e:
-                    errors.append({
+                    err = {
                         'source': source,
                         'row': dict(row),
                         'error': str(e),
-                    })
+                    }
+                    errors.append(err)
+                    if restore_log_path and not dry_run:
+                        self._log_restore_op(
+                            restore_log_path,
+                            {'kind': row.get('action', '?')},
+                            status='error', error=str(e),
+                        )
 
         return {
             'mode': MODE_LOGS,
@@ -1138,7 +1183,8 @@ class WpcomAdapter:
 
         return {'kind': 'unknown', 'source': source, 'action': action}
 
-    def restore_from_snapshot(self, backup_data, dry_run=False):
+    def restore_from_snapshot(self, backup_data, dry_run=False,
+                              restore_log_path=None):
         """
         Replay a full backup snapshot. Heavy-handed but works without logs.
 
@@ -1160,7 +1206,7 @@ class WpcomAdapter:
         errors = []
 
         def execute(op, fn, *args, verify=None):
-            """Run an op, verify the result, append to operations/errors."""
+            """Run an op, verify the result, stream to restore log."""
             operations.append(op)
             if dry_run:
                 return
@@ -1168,11 +1214,21 @@ class WpcomAdapter:
                 fn(*args)
             except WpcomApiError as e:
                 errors.append({'op': op, 'error': str(e)})
+                if restore_log_path:
+                    self._log_restore_op(
+                        restore_log_path, op,
+                        status='error', error=str(e),
+                    )
                 return
-            if verify:
-                err = verify()
-                if err:
-                    errors.append({'op': op, 'error': err})
+            verify_err = verify() if verify else None
+            if verify_err:
+                errors.append({'op': op, 'error': verify_err})
+            if restore_log_path:
+                self._log_restore_op(
+                    restore_log_path, op,
+                    status='verify_failed' if verify_err else 'ok',
+                    error=verify_err or '',
+                )
 
         with self._logging_suspended():
             backup_cats = backup_data.get('categories', [])
@@ -1307,8 +1363,17 @@ class WpcomAdapter:
                         ids.append(int(live['ID']))
                     if ids:
                         self.set_post_categories(int(post_id), ids)
+                    if restore_log_path:
+                        self._log_restore_op(
+                            restore_log_path, op, status='ok',
+                        )
                 except WpcomApiError as e:
                     errors.append({'op': op, 'error': str(e)})
+                    if restore_log_path:
+                        self._log_restore_op(
+                            restore_log_path, op,
+                            status='error', error=str(e),
+                        )
 
             # Step 4: restore default category.
             if default_slug:

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -12,12 +12,16 @@ Matches the WpCliAdapter interface so the orchestrating agent can swap
 between adapters transparently.
 """
 
+import csv
 import json
+import os
 import re
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from contextlib import contextmanager
+from datetime import datetime, timezone
 
 
 def wp_urlencode(params):
@@ -44,6 +48,35 @@ class WpcomApiError(Exception):
         self.status_code = status_code
         self.error = error
         super().__init__(f'WP.com API {status_code}: {error} - {message}')
+
+
+# Log row action types. Defined as constants so a typo in either the
+# writer or the reader becomes a NameError instead of a silent no-op.
+ACTION_SET_CATS = 'SET_CATS'
+ACTION_CREATE_CAT = 'CREATE_CAT'
+ACTION_DELETE_CAT = 'DELETE_CAT'
+ACTION_UPDATE_CAT = 'UPDATE_CAT'
+ACTION_SET_DEFAULT = 'SET_DEFAULT'
+
+# Sources for the combined replay stream in restore_from_logs.
+SOURCE_TERM = 'term'
+SOURCE_CHANGE = 'change'
+
+# restore() mode selection.
+MODE_AUTO = 'auto'
+MODE_LOGS = 'logs'
+MODE_SNAPSHOT = 'snapshot'
+
+
+def _term_snapshot(cat):
+    """Distill a category dict to the minimum needed to rehydrate it."""
+    return {
+        'ID': cat.get('ID'),
+        'name': cat.get('name'),
+        'slug': cat.get('slug'),
+        'description': cat.get('description', ''),
+        'parent': cat.get('parent', 0),
+    }
 
 
 class WpcomAdapter:
@@ -81,6 +114,13 @@ class WpcomAdapter:
         self.access_token = conn['access_token']
         self.site_url = config.get('site_url', '')
         self._category_cache = None
+        # When set via set_logging(), every mutating call appends to these
+        # TSV files so a later restore() can replay them in reverse.
+        self.changes_log_path = None
+        self.terms_log_path = None
+        # Track which log paths have already had a header row written this
+        # process so _append_tsv doesn't stat() the file on every row.
+        self._log_headers_written = set()
 
     # --- HTTP layer ---
 
@@ -165,28 +205,34 @@ class WpcomAdapter:
     def _invalidate_category_cache(self):
         self._category_cache = None
 
-    def _get_category_by_id(self, term_id):
+    def _find_category(self, predicate):
         """
-        Look up a category by term_id.
+        Find a category matching `predicate`. Cache-first, one refresh on miss.
 
-        Uses cache first, refreshes once on miss to handle
-        recently-created categories.
-
-        Args:
-            term_id: Integer category ID.
-
-        Returns:
-            Category dict, or None if not found.
+        Used by all the public lookup-by-X helpers below so they share
+        the same cache-then-refresh-on-miss behavior.
         """
         for cat in self._ensure_category_cache():
-            if cat['ID'] == term_id:
+            if predicate(cat):
                 return cat
-        # Cache miss -- refresh and retry.
         self._invalidate_category_cache()
         for cat in self._ensure_category_cache():
-            if cat['ID'] == term_id:
+            if predicate(cat):
                 return cat
         return None
+
+    def _get_category_by_id(self, term_id):
+        return self._find_category(lambda c: c.get('ID') == term_id)
+
+    def _lookup_category_by_slug(self, slug):
+        if not slug:
+            return None
+        return self._find_category(lambda c: c.get('slug') == slug)
+
+    def _lookup_category_by_name(self, name):
+        if not name:
+            return None
+        return self._find_category(lambda c: c.get('name') == name)
 
     def _get_category_count(self):
         """Get the current total number of categories on the site."""
@@ -277,7 +323,8 @@ class WpcomAdapter:
         with open(output_path, 'w', encoding='utf-8') as f:
             json.dump(all_posts, f, ensure_ascii=False)
 
-    def set_post_categories(self, post_id, category_ids):
+    def set_post_categories(self, post_id, category_ids,
+                            old_category_ids=None, post_title=''):
         """
         Set categories for a post by term IDs.
 
@@ -286,26 +333,62 @@ class WpcomAdapter:
 
         Args:
             post_id: Integer post ID.
-            category_ids: List of integer category IDs.
+            category_ids: List of integer category IDs to set.
+            old_category_ids: List of category IDs the post had before
+                this call. Required when logging is enabled — the
+                orchestrator already has this state from the export, so
+                we never spend an extra GET to recover it. When logging
+                is off this argument is ignored.
+            post_title: Optional title for the log row (display only).
 
         Raises:
             WpcomApiError: If any category ID is not found.
+            ValueError: If logging is enabled but old_category_ids is
+                not supplied (would produce an unrevertable log row).
         """
-        names = []
-        for cid in category_ids:
-            cat = self._get_category_by_id(cid)
-            if cat is None:
-                raise WpcomApiError(
-                    404, 'not_found', f'Category ID {cid} not found',
-                )
-            names.append(cat['name'])
+        names = [self._resolve_id_to_name(cid) for cid in category_ids]
+
+        old_names = []
+        if self.changes_log_path and not old_category_ids:
+            raise ValueError(
+                f'set_post_categories(post_id={post_id}): '
+                'old_category_ids is required when logging is enabled. '
+                'Pass the pre-change category IDs from the export so '
+                'the change log can record a reversible operation.'
+            )
+        if self.changes_log_path and old_category_ids:
+            old_names = [
+                cat['name']
+                for cid in old_category_ids
+                for cat in (self._get_category_by_id(cid),)
+                if cat is not None
+            ]
 
         self._post(
             f'/sites/{self.site_id}/posts/{post_id}',
             data={'categories': ','.join(names)},
         )
 
-    def create_category(self, name, slug, description=''):
+        if self.changes_log_path:
+            self._log_post_change(
+                action=ACTION_SET_CATS,
+                post_id=post_id,
+                post_title=post_title,
+                old_categories=old_names,
+                new_categories=names,
+                cats_added=[n for n in names if n not in old_names],
+                cats_removed=[n for n in old_names if n not in names],
+            )
+
+    def _resolve_id_to_name(self, term_id):
+        cat = self._get_category_by_id(term_id)
+        if cat is None:
+            raise WpcomApiError(
+                404, 'not_found', f'Category ID {term_id} not found',
+            )
+        return cat['name']
+
+    def create_category(self, name, slug, description='', parent=0):
         """
         Create a new category.
 
@@ -313,6 +396,7 @@ class WpcomAdapter:
             name: Display name.
             slug: URL slug.
             description: Category description.
+            parent: Parent category ID (0 for top-level).
 
         Returns:
             API response dict with the new category.
@@ -322,9 +406,19 @@ class WpcomAdapter:
             data['slug'] = slug
         if description:
             data['description'] = description
+        if parent:
+            data['parent'] = parent
 
         result = self._post(f'/sites/{self.site_id}/categories/new', data=data)
         self._invalidate_category_cache()
+        self._log_term_op(
+            ACTION_CREATE_CAT,
+            term_id=result.get('ID', 0),
+            slug=result.get('slug', slug or ''),
+            field='*',
+            old_value='',
+            new_value=json.dumps(_term_snapshot(result), ensure_ascii=False),
+        )
         return result
 
     def delete_category(self, term_id):
@@ -350,11 +444,22 @@ class WpcomAdapter:
             raise WpcomApiError(
                 404, 'not_found', f'Category {term_id} does not exist',
             )
+        # Capture the snapshot BEFORE the destructive call so revert can
+        # rehydrate the category exactly.
+        snapshot = json.dumps(_term_snapshot(cat), ensure_ascii=False)
         slug = urllib.parse.quote(cat['slug'], safe='')
         self._post(
             f'/sites/{self.site_id}/categories/slug:{slug}/delete',
         )
         self._invalidate_category_cache()
+        self._log_term_op(
+            ACTION_DELETE_CAT,
+            term_id=cat.get('ID', term_id),
+            slug=cat.get('slug', ''),
+            field='*',
+            old_value=snapshot,
+            new_value='',
+        )
 
     # --- Extended interface ---
 
@@ -390,6 +495,14 @@ class WpcomAdapter:
         # Copy to avoid mutating the caller's dict.
         payload = dict(fields)
 
+        # Snapshot old field values BEFORE the destructive call so the
+        # log row records what was actually replaced. Holding `current`
+        # alone is not enough — the cache invalidation after the POST
+        # leaves us with a stale reference whose contents could be
+        # overwritten by other code paths.
+        old_field_values = {f: current.get(f, '') for f in fields.keys()}
+        log_slug = current.get('slug', '')
+
         # Always include parent to prevent silent duplicate creation.
         if 'parent' not in payload:
             payload['parent'] = current.get('parent', 0)
@@ -412,6 +525,21 @@ class WpcomAdapter:
             )
 
         self._invalidate_category_cache()
+
+        # Log one row per field actually being changed.
+        for field, new_val in fields.items():
+            old_val = old_field_values.get(field, '')
+            if old_val == new_val:
+                continue
+            self._log_term_op(
+                ACTION_UPDATE_CAT,
+                term_id=term_id,
+                slug=log_slug,
+                field=field,
+                old_value='' if old_val is None else str(old_val),
+                new_value='' if new_val is None else str(new_val),
+            )
+
         return result
 
     def get_default_category(self):
@@ -435,6 +563,54 @@ class WpcomAdapter:
                 f'Default category {default_id} not found',
             )
         return cat
+
+    def set_default_category(self, term_id):
+        """
+        Change the site's default category.
+
+        WordPress assigns the default category to any post that would
+        otherwise be uncategorized. Changing it is a prerequisite to
+        deleting the current default. Logged so revert can restore it.
+
+        Args:
+            term_id: Integer term ID of the new default category.
+
+        Raises:
+            WpcomApiError: If the term doesn't exist.
+        """
+        if not isinstance(term_id, int):
+            raise TypeError(
+                f'term_id must be int, got {type(term_id).__name__}'
+            )
+        new_cat = self._get_category_by_id(term_id)
+        if new_cat is None:
+            raise WpcomApiError(
+                404, 'not_found', f'Category {term_id} not found',
+            )
+
+        # Capture current default for the inverse-replay log.
+        try:
+            old_cat = self.get_default_category()
+            old_id = old_cat.get('ID', 0)
+            old_slug = old_cat.get('slug', '')
+        except WpcomApiError as e:
+            if e.status_code == 404:
+                old_id, old_slug = 0, ''
+            else:
+                raise
+
+        self._post(
+            f'/sites/{self.site_id}/settings',
+            data={'default_category': term_id},
+        )
+        self._log_term_op(
+            ACTION_SET_DEFAULT,
+            term_id=term_id,
+            slug=new_cat.get('slug', ''),
+            field='default_category',
+            old_value=f'{old_id}:{old_slug}',
+            new_value=f'{term_id}:{new_cat.get("slug", "")}',
+        )
 
     def backup(self, output_path):
         """
@@ -500,3 +676,615 @@ class WpcomAdapter:
 
         with open(output_path, 'w', encoding='utf-8') as f:
             json.dump(backup_data, f, indent=2, ensure_ascii=False)
+
+    # --- Logging hooks ---
+    #
+    # Term and post mutations append to TSV logs whose schemas match what
+    # parse_change_log() and parse_terms_log() in lib/helpers.py expect.
+    # Logging is opt-in: an adapter that hasn't been told a log path stays
+    # silent, so reads/exports never write logs.
+
+    POST_LOG_HEADER = (
+        'timestamp', 'action', 'post_id', 'post_title',
+        'old_categories', 'new_categories', 'cats_added', 'cats_removed',
+    )
+    TERM_LOG_HEADER = (
+        'timestamp', 'action', 'term_id', 'slug',
+        'field', 'old_value', 'new_value',
+    )
+
+    def set_logging(self, changes_log_path=None, terms_log_path=None):
+        """
+        Enable mutation logging to TSV files.
+
+        Once set, every create/update/delete/set_post_categories/
+        set_default_category call appends a row to the appropriate log.
+        Pass None to either argument to leave that log disabled.
+
+        Args:
+            changes_log_path: Path for the post-change TSV log.
+            terms_log_path: Path for the term-operation TSV log.
+        """
+        self.changes_log_path = changes_log_path
+        self.terms_log_path = terms_log_path
+
+    @contextmanager
+    def _logging_suspended(self):
+        """Suspend logging within a `with` block — used during restore."""
+        saved_changes = self.changes_log_path
+        saved_terms = self.terms_log_path
+        self.changes_log_path = None
+        self.terms_log_path = None
+        try:
+            yield
+        finally:
+            self.changes_log_path = saved_changes
+            self.terms_log_path = saved_terms
+
+    def _append_tsv(self, path, header, row):
+        """
+        Append a single row to a TSV log, writing the header on first use.
+
+        Header-written state is cached in self._log_headers_written so we
+        avoid two stat() calls per row at scale (apply runs touch
+        thousands of rows). The cache is per-process; if the same path is
+        appended to from a previous process, the header check still falls
+        through to a single os.path.getsize() probe on the first call.
+        """
+        if path not in self._log_headers_written:
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            try:
+                already_has_header = os.path.getsize(path) > 0
+            except FileNotFoundError:
+                already_has_header = False
+            with open(path, 'a', newline='', encoding='utf-8') as f:
+                writer = csv.writer(f, delimiter='\t')
+                if not already_has_header:
+                    writer.writerow(header)
+                writer.writerow(row)
+            self._log_headers_written.add(path)
+            return
+
+        with open(path, 'a', newline='', encoding='utf-8') as f:
+            csv.writer(f, delimiter='\t').writerow(row)
+
+    @staticmethod
+    def _log_timestamp():
+        # Microsecond resolution so the restore agent can recover the
+        # exact apply order even when many operations land in the same
+        # second. Format sorts lexically.
+        return datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+
+    def _log_term_op(self, action, term_id, slug, field, old_value, new_value):
+        if not self.terms_log_path:
+            return
+        ts = self._log_timestamp()
+        self._append_tsv(
+            self.terms_log_path,
+            self.TERM_LOG_HEADER,
+            (ts, action, str(term_id), slug, field, old_value, new_value),
+        )
+
+    def _log_post_change(self, action, post_id, post_title,
+                         old_categories, new_categories,
+                         cats_added, cats_removed):
+        if not self.changes_log_path:
+            return
+        ts = self._log_timestamp()
+        self._append_tsv(
+            self.changes_log_path,
+            self.POST_LOG_HEADER,
+            (
+                ts, action, str(post_id), post_title,
+                '|'.join(old_categories),
+                '|'.join(new_categories),
+                '|'.join(cats_added),
+                '|'.join(cats_removed),
+            ),
+        )
+
+    # --- Restore ---
+
+    def restore(self, backup_path=None, changes_log_path=None,
+                terms_log_path=None, mode=MODE_AUTO, dry_run=False):
+        """
+        Revert a Taxonomist run.
+
+        Args:
+            backup_path: Path to backup-{timestamp}.json. Required for
+                snapshot mode and used as the auto-mode fallback when
+                no logs are present.
+            changes_log_path: Path to the post change TSV (optional).
+            terms_log_path: Path to the term-op TSV (optional).
+            mode: MODE_AUTO (use logs if any present, else snapshot),
+                MODE_LOGS (force log replay; error if no logs), or
+                MODE_SNAPSHOT (force full backup replay).
+            dry_run: If True, return planned operations without writing.
+
+        Returns:
+            Dict with keys: mode, operations, errors, dry_run.
+        """
+        term_rows = _try_parse_log(terms_log_path, _parse_terms_tsv)
+        change_rows = _try_parse_log(changes_log_path, _parse_changes_tsv)
+        have_both_logs = bool(term_rows) and bool(change_rows)
+        have_any_log = bool(term_rows) or bool(change_rows)
+
+        if mode == MODE_LOGS:
+            if not have_any_log:
+                raise ValueError(
+                    'restore mode=logs requires at least one of '
+                    'changes_log_path or terms_log_path to exist'
+                )
+            return self.restore_from_logs(change_rows, term_rows, dry_run=dry_run)
+
+        if mode == MODE_AUTO:
+            # Require BOTH logs for an inverse replay. A partial replay
+            # (e.g., post assignments only) would leave orphaned created/
+            # deleted categories behind — worse than a full snapshot undo.
+            if have_both_logs:
+                return self.restore_from_logs(
+                    change_rows, term_rows, dry_run=dry_run,
+                )
+            # Fall through to snapshot. If only one log exists, include
+            # a note so the agent can surface it to the user.
+
+        if not backup_path:
+            raise ValueError(
+                'restore: no logs and no backup_path provided — nothing to do'
+                if mode == MODE_AUTO
+                else 'restore mode=snapshot requires backup_path'
+            )
+        with open(backup_path, encoding='utf-8') as f:
+            result = self.restore_from_snapshot(json.load(f), dry_run=dry_run)
+        if mode == MODE_AUTO and have_any_log and not have_both_logs:
+            present = 'terms' if term_rows else 'changes'
+            missing = 'changes' if term_rows else 'terms'
+            result['errors'].append({
+                'op': None,
+                'error': (
+                    f'Only the {present} log was found ({missing} log is '
+                    'missing). Fell back to full snapshot restore to avoid '
+                    'a partial revert.'
+                ),
+            })
+        return result
+
+    def restore_from_logs(self, change_rows, term_rows, dry_run=False):
+        """
+        Inverse-replay change and term log rows in reverse-time order.
+
+        Accepts already-parsed row lists (use parse_change_log /
+        parse_terms_log from helpers.py to get them) so callers can
+        massage them first if needed. See restore() for the contract.
+        """
+        # Tag each row with (timestamp, source-priority, position) so
+        # ties within a second fall back to natural file order. Term ops
+        # have priority 0 because they happen first in apply.md's order
+        # (create → update → posts → delete); post changes have 1.
+        # Sort ascending then reverse — that way ties also invert,
+        # unlike sort(reverse=True) which preserves input order on ties.
+        combined = [
+            (r.get('timestamp', ''), 0, i, SOURCE_TERM, r)
+            for i, r in enumerate(term_rows or [])
+        ] + [
+            (r.get('timestamp', ''), 1, i, SOURCE_CHANGE, r)
+            for i, r in enumerate(change_rows or [])
+        ]
+        combined.sort(key=lambda x: (x[0], x[1], x[2]))
+        combined.reverse()
+
+        operations = []
+        errors = []
+
+        # Build a term_id→slug map from the log so we can resolve backup
+        # parent IDs to live categories (e.g., when a deleted child
+        # category's parent was also deleted and recreated with a new ID).
+        id_to_slug = {}
+        for r in (term_rows or []):
+            tid = r.get('term_id')
+            slug = r.get('slug')
+            if tid and slug:
+                id_to_slug[int(tid)] = slug
+
+        with self._logging_suspended():
+            for _ts, _pri, _pos, source, row in combined:
+                try:
+                    op = self._invert_op(source, row, dry_run, id_to_slug)
+                    if op is not None:
+                        operations.append(op)
+                except (WpcomApiError, ValueError, KeyError, TypeError) as e:
+                    errors.append({
+                        'source': source,
+                        'row': dict(row),
+                        'error': str(e),
+                    })
+
+        return {
+            'mode': MODE_LOGS,
+            'operations': operations,
+            'errors': errors,
+            'dry_run': dry_run,
+        }
+
+    def _invert_op(self, source, row, dry_run, id_to_slug=None):
+        """Invert a single logged operation. Returns a description dict."""
+        action = row.get('action', '')
+
+        if source == SOURCE_CHANGE and action == ACTION_SET_CATS:
+            post_id = int(row.get('post_id') or 0)
+            old_cat_names = [
+                n for n in (row.get('old_categories') or '').split('|') if n
+            ]
+            op = {
+                'kind': 'set_post_categories',
+                'post_id': post_id,
+                'restore_to': old_cat_names,
+                'post_title': row.get('post_title', ''),
+            }
+            if dry_run:
+                return op
+            ids = []
+            for name in old_cat_names:
+                cat = self._lookup_category_by_name(name)
+                if cat is None:
+                    raise WpcomApiError(
+                        404, 'not_found',
+                        f'Cannot restore post {post_id}: category '
+                        f'"{name}" no longer exists',
+                    )
+                ids.append(cat['ID'])
+            self.set_post_categories(post_id, ids)
+            return op
+
+        if source == SOURCE_TERM and action == ACTION_CREATE_CAT:
+            # Inverse of CREATE is DELETE. Look up by slug (term_id may
+            # be stale if a previous inverse step recreated the term).
+            slug = row.get('slug', '')
+            cat = self._lookup_category_by_slug(slug)
+            op = {
+                'kind': 'delete_category',
+                'slug': slug,
+                'term_id': cat['ID'] if cat else None,
+            }
+            if cat is None:
+                if not dry_run:
+                    op['note'] = 'category already absent'
+                return op
+            if dry_run:
+                return op
+            self.delete_category(int(cat['ID']))
+            return op
+
+        if source == SOURCE_TERM and action == ACTION_DELETE_CAT:
+            # Inverse of DELETE is CREATE, rehydrated from old_value JSON.
+            try:
+                snapshot = json.loads(row.get('old_value') or '{}')
+            except json.JSONDecodeError as e:
+                raise WpcomApiError(
+                    400, 'invalid_log',
+                    f'Could not parse DELETE_CAT snapshot: {e}',
+                )
+            op = {
+                'kind': 'create_category',
+                'name': snapshot.get('name'),
+                'slug': snapshot.get('slug'),
+                'description': snapshot.get('description', ''),
+                'parent': snapshot.get('parent', 0),
+            }
+            if dry_run:
+                return op
+            # Idempotency: don't duplicate if revert is re-run.
+            if self._lookup_category_by_slug(snapshot.get('slug', '')) is not None:
+                op['note'] = 'category already present'
+                return op
+            result = self.create_category(
+                snapshot.get('name', ''),
+                snapshot.get('slug', ''),
+                snapshot.get('description', ''),
+            )
+            # Restore parent-child relationship. The snapshot stores the
+            # backup's term_id as parent, which may not match the live ID
+            # (e.g., if the parent was also deleted and recreated). Resolve
+            # through id_to_slug → live slug lookup, same approach as
+            # restore_from_snapshot's hierarchy step.
+            backup_parent_id = snapshot.get('parent', 0)
+            if backup_parent_id and result.get('ID'):
+                live_parent = None
+                if id_to_slug:
+                    parent_slug = id_to_slug.get(backup_parent_id)
+                    if parent_slug:
+                        live_parent = self._lookup_category_by_slug(parent_slug)
+                # Fallback: the parent may still exist with its original ID.
+                if live_parent is None:
+                    live_parent = self._get_category_by_id(backup_parent_id)
+                if live_parent is not None:
+                    try:
+                        self.update_category(
+                            int(result['ID']),
+                            {'parent': int(live_parent['ID'])},
+                        )
+                    except WpcomApiError:
+                        op['note'] = (
+                            f'parent {backup_parent_id} found but could '
+                            'not be set'
+                        )
+                else:
+                    op['note'] = (
+                        f'parent {backup_parent_id} not found on live site'
+                    )
+            return op
+
+        if source == SOURCE_TERM and action == ACTION_UPDATE_CAT:
+            slug = row.get('slug', '')
+            field = row.get('field', '')
+            old_value = row.get('old_value', '')
+            op = {
+                'kind': 'update_category',
+                'slug': slug,
+                'field': field,
+                'restore_to': old_value,
+            }
+            if dry_run:
+                return op
+            # term_id is stable across renames, so try it first. Fall
+            # back to slug lookup (pre-change slug, then new_value for
+            # slug-rename rows).
+            term_id = int(row.get('term_id') or 0)
+            cat = self._get_category_by_id(term_id) if term_id else None
+            if cat is None:
+                cat = self._lookup_category_by_slug(slug)
+            if cat is None and field == 'slug':
+                cat = self._lookup_category_by_slug(row.get('new_value', ''))
+            if cat is None:
+                raise WpcomApiError(
+                    404, 'not_found',
+                    f'Cannot revert UPDATE_CAT on slug "{slug}": '
+                    'category not found on live site',
+                )
+            self.update_category(int(cat['ID']), {field: old_value})
+            return op
+
+        if source == SOURCE_TERM and action == ACTION_SET_DEFAULT:
+            # old_value is "id:slug"; prefer the slug since IDs may shift.
+            old_value = row.get('old_value', '')
+            old_slug = old_value.split(':', 1)[-1] if ':' in old_value else ''
+            op = {
+                'kind': 'set_default_category',
+                'restore_slug': old_slug,
+            }
+            if dry_run:
+                return op
+            cat = self._lookup_category_by_slug(old_slug)
+            if cat is None:
+                raise WpcomApiError(
+                    404, 'not_found',
+                    f'Cannot restore default category to "{old_slug}": '
+                    'category not found',
+                )
+            self.set_default_category(int(cat['ID']))
+            return op
+
+        return {'kind': 'unknown', 'source': source, 'action': action}
+
+    def restore_from_snapshot(self, backup_data, dry_run=False):
+        """
+        Replay a full backup snapshot. Heavy-handed but works without logs.
+
+        Mirrors the steps of lib/restore.php (categories without parents
+        → reconcile descriptions → post assignments → default category →
+        delete extras), but does NOT reproduce its known bugs: on slug
+        collision we ABORT with a clear error rather than silently
+        overwriting (lib/restore.php:90), and we never use temporary
+        names that can leak on crash (lib/restore.php:109).
+
+        Args:
+            backup_data: Parsed backup JSON dict (from backup() output).
+            dry_run: If True, plan operations without making any writes.
+
+        Returns:
+            Result dict matching restore_from_logs().
+        """
+        operations = []
+        errors = []
+
+        def execute(op, fn, *args):
+            """Run an op and append it to operations / errors. Closure."""
+            operations.append(op)
+            if dry_run:
+                return
+            try:
+                fn(*args)
+            except WpcomApiError as e:
+                errors.append({'op': op, 'error': str(e)})
+
+        with self._logging_suspended():
+            backup_cats = backup_data.get('categories', [])
+            backup_posts = backup_data.get('post_categories', [])
+            default_slug = backup_data.get('default_category_slug', '')
+
+            live_cats = self.list_categories()
+            live_by_slug = {c['slug']: c for c in live_cats}
+
+            # Step 1: recreate any missing backup categories and rename
+            # any whose name has drifted. Track whether we mutated so we
+            # only refresh the cache when something actually changed.
+            # Categories are created without parent first; hierarchy is
+            # reconciled in step 2 after all categories exist (mirroring
+            # the two-pass approach in lib/restore.php).
+            cats_mutated = False
+            for cat in backup_cats:
+                slug = cat.get('slug', '')
+                if not slug:
+                    continue
+                live = live_by_slug.get(slug)
+                if live is None:
+                    execute(
+                        {'kind': 'create_category', 'slug': slug,
+                         'name': cat.get('name', ''),
+                         'description': cat.get('description', '')},
+                        self.create_category,
+                        cat.get('name', ''), slug, cat.get('description', ''),
+                    )
+                    cats_mutated = True
+                elif live.get('name') != cat.get('name'):
+                    execute(
+                        {'kind': 'update_category', 'slug': slug,
+                         'field': 'name', 'restore_to': cat.get('name', '')},
+                        self.update_category,
+                        int(live['ID']), {'name': cat.get('name', '')},
+                    )
+                    cats_mutated = True
+
+            if cats_mutated and not dry_run:
+                self._invalidate_category_cache()
+                live_cats = self.list_categories()
+                live_by_slug = {c['slug']: c for c in live_cats}
+
+            # Step 2a: reconcile parent-child hierarchy. Backup parent
+            # values are the backup's term_ids, not live IDs, so we
+            # resolve via backup_id→slug→live_id.
+            backup_id_to_slug = {
+                c['term_id']: c['slug'] for c in backup_cats
+                if c.get('term_id') and c.get('slug')
+            }
+            for cat in backup_cats:
+                slug = cat.get('slug', '')
+                live = live_by_slug.get(slug)
+                if not live:
+                    continue
+                backup_parent_id = cat.get('parent', 0)
+                if backup_parent_id:
+                    parent_slug = backup_id_to_slug.get(backup_parent_id, '')
+                    parent_live = live_by_slug.get(parent_slug)
+                    desired_parent = int(parent_live['ID']) if parent_live else 0
+                else:
+                    desired_parent = 0
+                if live.get('parent', 0) != desired_parent:
+                    execute(
+                        {'kind': 'update_category', 'slug': slug,
+                         'field': 'parent', 'restore_to': desired_parent},
+                        self.update_category,
+                        int(live['ID']), {'parent': desired_parent},
+                    )
+
+            # Step 2b: reconcile descriptions.
+            for cat in backup_cats:
+                slug = cat.get('slug', '')
+                live = live_by_slug.get(slug)
+                if not live:
+                    continue
+                desired_desc = cat.get('description', '')
+                if (live.get('description') or '') != desired_desc:
+                    execute(
+                        {'kind': 'update_category', 'slug': slug,
+                         'field': 'description', 'restore_to': desired_desc},
+                        self.update_category,
+                        int(live['ID']), {'description': desired_desc},
+                    )
+
+            # Step 3: restore post category assignments. Pre-collect any
+            # slugs we don't see live and refresh the cache once before
+            # the loop, instead of thrashing per-iteration.
+            needed_slugs = {
+                s
+                for pc in backup_posts
+                for s in (pc.get('category_slugs') or [])
+            }
+            if not dry_run and needed_slugs - live_by_slug.keys():
+                self._invalidate_category_cache()
+                live_cats = self.list_categories()
+                live_by_slug = {c['slug']: c for c in live_cats}
+
+            for pc in backup_posts:
+                post_id = pc.get('post_id')
+                slugs = pc.get('category_slugs', []) or []
+                op = {
+                    'kind': 'set_post_categories',
+                    'post_id': post_id,
+                    'restore_to': slugs,
+                }
+                operations.append(op)
+                if dry_run:
+                    continue
+                try:
+                    ids = []
+                    for s in slugs:
+                        live = live_by_slug.get(s)
+                        if live is None:
+                            raise WpcomApiError(
+                                404, 'not_found',
+                                f'Category slug "{s}" missing during restore',
+                            )
+                        ids.append(int(live['ID']))
+                    if ids:
+                        self.set_post_categories(int(post_id), ids)
+                except WpcomApiError as e:
+                    errors.append({'op': op, 'error': str(e)})
+
+            # Step 4: restore default category.
+            if default_slug:
+                live = live_by_slug.get(default_slug)
+                if live is not None:
+                    execute(
+                        {'kind': 'set_default_category',
+                         'restore_slug': default_slug},
+                        self.set_default_category,
+                        int(live['ID']),
+                    )
+
+            # Step 5: delete categories that exist live but not in the
+            # backup (created after the snapshot). Skip the default to
+            # avoid orphaning posts.
+            backup_slugs = {c.get('slug', '') for c in backup_cats}
+            try:
+                current_default = self.get_default_category()
+            except WpcomApiError:
+                current_default = None
+            for live in live_cats:
+                slug = live.get('slug', '')
+                if not slug or slug in backup_slugs:
+                    continue
+                if current_default and live.get('ID') == current_default.get('ID'):
+                    errors.append({
+                        'op': {'kind': 'delete_category', 'slug': slug},
+                        'error': 'refusing to delete current default category',
+                    })
+                    continue
+                execute(
+                    {'kind': 'delete_category', 'slug': slug},
+                    self.delete_category,
+                    int(live['ID']),
+                )
+
+        return {
+            'mode': MODE_SNAPSHOT,
+            'operations': operations,
+            'errors': errors,
+            'dry_run': dry_run,
+        }
+
+
+def _parse_changes_tsv(path):
+    from helpers import parse_change_log
+    return parse_change_log(path)
+
+
+def _parse_terms_tsv(path):
+    from helpers import parse_terms_log
+    return parse_terms_log(path)
+
+
+def _try_parse_log(path, parser):
+    """
+    Read a TSV log without an existence pre-check (TOCTOU-safe).
+
+    Returns [] for any None path, missing file, or empty file.
+    """
+    if not path:
+        return []
+    try:
+        return parser(path)
+    except FileNotFoundError:
+        return []

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -442,6 +442,12 @@ def validate_category_slugs(suggestions, valid_slugs):
     }
 
 
+def _read_tsv_dicts(log_path):
+    """Read a TSV file as a list of dicts keyed by header row."""
+    with open(log_path, newline='') as f:
+        return list(csv.DictReader(f, delimiter='\t'))
+
+
 def parse_change_log(log_path):
     """
     Parse a TSV change log file into a list of change dicts.
@@ -449,12 +455,23 @@ def parse_change_log(log_path):
     Uses csv.DictReader so quoted tabs and embedded newlines are handled the
     same way they were written by PHP's fputcsv().
 
-    Args:
-        log_path: Path to the TSV log file.
-
-    Returns:
-        List of dicts with keys: timestamp, action, post_id, post_title,
-        old_categories, new_categories, cats_added, cats_removed.
+    Returns dicts with keys: timestamp, action, post_id, post_title,
+    old_categories, new_categories, cats_added, cats_removed.
     """
-    with open(log_path, newline='') as f:
-        return list(csv.DictReader(f, delimiter='\t'))
+    return _read_tsv_dicts(log_path)
+
+
+def parse_terms_log(log_path):
+    """
+    Parse a TSV term-operation log into a list of dicts.
+
+    The terms log records create/delete/update/set-default operations on
+    categories so a later restore can replay the inverse. The wpcom adapter
+    writes one row per term operation; for UPDATE_CAT, one row per changed
+    field. DELETE_CAT rows store the full pre-delete term as JSON in
+    `old_value` so the category can be rehydrated exactly.
+
+    Returns dicts with keys: timestamp, action, term_id, slug, field,
+    old_value, new_value.
+    """
+    return _read_tsv_dicts(log_path)

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
 from adapters.wpcom_adapter import (
-    WpcomAdapter, WpcomApiError, wp_urlencode,
+    WpcomAdapter, WpcomApiError, PartialRestoreError, wp_urlencode,
     ACTION_CREATE_CAT, ACTION_DELETE_CAT, ACTION_UPDATE_CAT,
     ACTION_SET_CATS, ACTION_SET_DEFAULT,
     MODE_AUTO, MODE_LOGS, MODE_SNAPSHOT,
@@ -870,6 +870,119 @@ class TestRestoreAutoMode(unittest.TestCase):
         adapter = FakeWpcom(cats=_make_cats())
         with self.assertRaises(ValueError):
             adapter.restore()
+
+
+class TestPartialRestoreError(unittest.TestCase):
+    """Tests for partial failure signaling."""
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix='taxo-test-')
+        self.backup = os.path.join(self.workdir, 'backup.json')
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+
+    def test_clean_restore_returns_result(self):
+        """A successful restore should return the result dict, not raise."""
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.backup(self.backup)
+        adapter.create_category('X', 'x')
+
+        result = adapter.restore(
+            backup_path=self.backup, mode=MODE_SNAPSHOT, dry_run=False,
+        )
+        self.assertFalse(result['partial'])
+        self.assertFalse(result['errors'])
+
+    def test_partial_restore_raises(self):
+        """A restore with errors must raise PartialRestoreError."""
+        workdir = tempfile.mkdtemp(prefix='taxo-partial-')
+        try:
+            terms_log = os.path.join(workdir, 'terms.tsv')
+            changes_log = os.path.join(workdir, 'changes.tsv')
+
+            # Write a changes log that references a category name that
+            # doesn't exist on the live site. The revert will fail to
+            # find it, producing an error.
+            adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+            adapter.set_logging(changes_log, terms_log)
+            adapter.create_category('Ephemeral', 'ephemeral')
+            eid = next(c['ID'] for c in adapter.cats.values()
+                       if c['slug'] == 'ephemeral')
+            adapter.set_post_categories(
+                123, [eid], old_category_ids=[2], post_title='Hello',
+            )
+            adapter.set_logging()
+
+            # Now delete the original 'Tech' category so the revert can't
+            # restore post 123 back to ['Tech'] — it's gone.
+            adapter.delete_category(2)
+
+            with self.assertRaises(PartialRestoreError) as ctx:
+                adapter.restore(
+                    changes_log_path=changes_log,
+                    terms_log_path=terms_log,
+                    mode=MODE_LOGS,
+                    dry_run=False,
+                )
+            result = ctx.exception.result
+            self.assertTrue(result['partial'])
+            self.assertTrue(len(result['errors']) > 0)
+        finally:
+            shutil.rmtree(workdir)
+
+    def test_partial_flag_on_result(self):
+        """The result dict always has a 'partial' boolean."""
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.backup(self.backup)
+
+        result = adapter.restore(
+            backup_path=self.backup, mode=MODE_SNAPSHOT, dry_run=True,
+        )
+        self.assertIn('partial', result)
+        self.assertIsInstance(result['partial'], bool)
+
+    def test_dry_run_with_errors_does_not_raise(self):
+        """Dry-run should never raise even if there would be errors."""
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.backup(self.backup)
+
+        # Dry-run always succeeds without raising.
+        result = adapter.restore(
+            backup_path=self.backup, mode=MODE_SNAPSHOT, dry_run=True,
+        )
+        self.assertFalse(result['partial'])
+
+
+class TestReadBackVerification(unittest.TestCase):
+    """Tests for post-mutation read-back verification."""
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix='taxo-test-')
+        self.changes = os.path.join(self.workdir, 'changes.tsv')
+        self.terms = os.path.join(self.workdir, 'terms.tsv')
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+
+    def test_verification_passes_on_clean_restore(self):
+        """No verification errors when mutations succeed normally."""
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.set_logging(terms_log_path=self.terms)
+        adapter.create_category('X', 'x-cat', 'desc')
+        adapter.set_logging()
+
+        with open(self.changes, 'w') as f:
+            f.write('')
+
+        result = adapter.restore(
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS, dry_run=False,
+        )
+        # No verification keys should appear on ops.
+        for op in result['operations']:
+            self.assertNotIn('verification', op)
 
 
 if __name__ == '__main__':

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -3,11 +3,16 @@ Tests for the WordPress.com API adapter.
 
 Uses unittest.mock to patch urllib.request.urlopen so no real HTTP
 requests are made. Verifies issue #1-4 defenses and API interactions.
+
+The restore/logging tests use FakeWpcom, a subclass that overrides
+_request() with an in-memory category/post store so the restore logic
+can be exercised end-to-end without complex mock response choreography.
 """
 
 import io
 import json
 import os
+import shutil
 import sys
 import tempfile
 import unittest
@@ -15,7 +20,12 @@ import urllib.error
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
-from adapters.wpcom_adapter import WpcomAdapter, WpcomApiError, wp_urlencode
+from adapters.wpcom_adapter import (
+    WpcomAdapter, WpcomApiError, wp_urlencode,
+    ACTION_CREATE_CAT, ACTION_DELETE_CAT, ACTION_UPDATE_CAT,
+    ACTION_SET_CATS, ACTION_SET_DEFAULT,
+    MODE_AUTO, MODE_LOGS, MODE_SNAPSHOT,
+)
 
 
 VALID_CONFIG = {
@@ -418,6 +428,448 @@ class TestBackup(unittest.TestCase):
             self.assertEqual(backup['post_categories'][0]['post_id'], 100)
         finally:
             os.unlink(output_path)
+
+
+# --- FakeWpcom for restore/logging tests ---
+
+class FakeWpcom(WpcomAdapter):
+    """In-memory WP.com adapter for testing restore/logging logic."""
+
+    def __init__(self, cats=None, posts=None, default_id=1):
+        super().__init__(VALID_CONFIG)
+        self.cats = dict(cats or {})
+        self.posts = dict(posts or {})
+        self.default_id = default_id
+        self.next_id = max(
+            list(self.cats.keys()) + list(self.posts.keys()) + [0]
+        ) + 100
+        self._category_cache = list(self.cats.values())
+
+    def list_categories(self):
+        self._category_cache = list(self.cats.values())
+        return self._category_cache
+
+    def _get_category_count(self):
+        return len(self.cats)
+
+    def _request(self, method, path, data=None, params=None):
+        if path.endswith('/categories'):
+            return {
+                'categories': list(self.cats.values()),
+                'found': len(self.cats),
+            }
+        if path.endswith('/categories/new'):
+            tid = self.next_id
+            self.next_id += 1
+            cat = {
+                'ID': tid, 'name': data.get('name', ''),
+                'slug': data.get('slug') or '',
+                'description': data.get('description', ''),
+                'parent': int(data.get('parent', 0) or 0),
+                'post_count': 0,
+            }
+            self.cats[tid] = cat
+            return cat
+        if '/categories/slug:' in path and path.endswith('/delete'):
+            slug = path.split('/categories/slug:')[1].split('/')[0]
+            for tid, c in list(self.cats.items()):
+                if c['slug'] == slug:
+                    del self.cats[tid]
+                    return {'success': True}
+            raise WpcomApiError(404, 'not_found', slug)
+        if '/categories/slug:' in path:
+            slug = path.split('/categories/slug:')[1]
+            for c in self.cats.values():
+                if c['slug'] == slug:
+                    for k, v in (data or {}).items():
+                        if k == 'parent':
+                            v = int(v or 0)
+                        c[k] = v
+                    return c
+            raise WpcomApiError(404, 'not_found', slug)
+        if path.endswith('/posts'):
+            return {
+                'posts': [
+                    {'ID': p['ID'], 'title': p.get('title', ''),
+                     'categories': p.get('categories', {})}
+                    for p in self.posts.values()
+                ],
+                'meta': {},
+            }
+        if '/posts/' in path and method == 'POST':
+            pid = int(path.split('/posts/')[1])
+            names = [
+                n.strip()
+                for n in (data or {}).get('categories', '').split(',')
+                if n.strip()
+            ]
+            cat_hash = {}
+            for n in names:
+                for c in self.cats.values():
+                    if c['name'] == n:
+                        cat_hash[n] = c
+                        break
+            self.posts[pid]['categories'] = cat_hash
+            return self.posts[pid]
+        if '/posts/' in path and method == 'GET':
+            pid = int(path.split('/posts/')[1])
+            return self.posts[pid]
+        if path.endswith('/settings') and method == 'GET':
+            return {'settings': {'default_category': self.default_id}}
+        if path.endswith('/settings') and method == 'POST':
+            self.default_id = int(
+                data.get('default_category', self.default_id)
+            )
+            return {}
+        raise RuntimeError(f'unstubbed: {method} {path}')
+
+
+def _make_cats():
+    return {
+        1: {'ID': 1, 'name': 'General', 'slug': 'general',
+            'description': '', 'parent': 0, 'post_count': 0},
+        2: {'ID': 2, 'name': 'Tech', 'slug': 'tech',
+            'description': 'old desc', 'parent': 0, 'post_count': 5},
+    }
+
+
+def _make_posts():
+    return {
+        123: {'ID': 123, 'title': 'Hello',
+              'categories': {
+                  'Tech': {'ID': 2, 'name': 'Tech', 'slug': 'tech',
+                           'parent': 0},
+              }},
+    }
+
+
+class TestLogging(unittest.TestCase):
+    """Tests for the term/post mutation logging hooks."""
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix='taxo-test-')
+        self.changes = os.path.join(self.workdir, 'changes.tsv')
+        self.terms = os.path.join(self.workdir, 'terms.tsv')
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+
+    def test_create_category_logs_to_terms(self):
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.set_logging(terms_log_path=self.terms)
+        adapter.create_category('New', 'new-cat', 'desc')
+        from helpers import parse_terms_log
+        rows = parse_terms_log(self.terms)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['action'], ACTION_CREATE_CAT)
+        self.assertEqual(rows[0]['slug'], 'new-cat')
+
+    def test_delete_category_logs_full_snapshot(self):
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.set_logging(terms_log_path=self.terms)
+        adapter.delete_category(2)
+        from helpers import parse_terms_log
+        rows = parse_terms_log(self.terms)
+        self.assertEqual(rows[0]['action'], ACTION_DELETE_CAT)
+        snapshot = json.loads(rows[0]['old_value'])
+        self.assertEqual(snapshot['slug'], 'tech')
+        self.assertEqual(snapshot['description'], 'old desc')
+
+    def test_update_category_logs_per_field(self):
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.set_logging(terms_log_path=self.terms)
+        adapter.update_category(2, {'description': 'new', 'name': 'Tech 2'})
+        from helpers import parse_terms_log
+        rows = parse_terms_log(self.terms)
+        fields = {r['field'] for r in rows}
+        self.assertIn('description', fields)
+        self.assertIn('name', fields)
+        desc_row = next(r for r in rows if r['field'] == 'description')
+        self.assertEqual(desc_row['old_value'], 'old desc')
+        self.assertEqual(desc_row['new_value'], 'new')
+
+    def test_set_post_categories_logs_change(self):
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.set_logging(changes_log_path=self.changes)
+        adapter.set_post_categories(
+            123, [1, 2], old_category_ids=[2], post_title='Hello',
+        )
+        from helpers import parse_change_log
+        rows = parse_change_log(self.changes)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['action'], ACTION_SET_CATS)
+        self.assertEqual(rows[0]['old_categories'], 'Tech')
+        self.assertIn('General', rows[0]['new_categories'])
+
+    def test_set_post_categories_raises_without_old_ids(self):
+        """Codex fix #3: must reject calls that would produce bad log rows."""
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.set_logging(changes_log_path=self.changes)
+        with self.assertRaises(ValueError) as ctx:
+            adapter.set_post_categories(123, [2])
+        self.assertIn('old_category_ids is required', str(ctx.exception))
+
+    def test_set_default_logs(self):
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.set_logging(terms_log_path=self.terms)
+        adapter.set_default_category(2)
+        from helpers import parse_terms_log
+        rows = parse_terms_log(self.terms)
+        self.assertEqual(rows[0]['action'], ACTION_SET_DEFAULT)
+        self.assertIn('general', rows[0]['old_value'])
+
+
+class TestRestoreFromLogs(unittest.TestCase):
+    """Tests for inverse-replay restore."""
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix='taxo-test-')
+        self.changes = os.path.join(self.workdir, 'changes.tsv')
+        self.terms = os.path.join(self.workdir, 'terms.tsv')
+        self.backup = os.path.join(self.workdir, 'backup.json')
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+
+    def _apply_and_revert(self):
+        """Run a mini apply then revert. Returns (adapter, result)."""
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.backup(self.backup)
+        adapter.set_logging(self.changes, self.terms)
+
+        # Simulate a Taxonomist apply run.
+        adapter.create_category('Remote Work', 'remote-work', 'WFH stuff')
+        adapter.update_category(2, {'description': 'new desc'})
+        new_id = max(adapter.cats.keys())
+        adapter.set_post_categories(
+            123, [2, new_id], old_category_ids=[2], post_title='Hello',
+        )
+        adapter.set_default_category(2)
+        adapter.delete_category(1)
+
+        adapter.set_logging()  # disable before restore
+        result = adapter.restore(
+            backup_path=self.backup,
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS,
+            dry_run=False,
+        )
+        return adapter, result
+
+    def test_round_trip(self):
+        """Apply + revert should recover the baseline exactly."""
+        adapter, result = self._apply_and_revert()
+        self.assertFalse(result['errors'])
+        self.assertEqual(result['mode'], MODE_LOGS)
+
+        with open(self.backup) as f:
+            baseline = json.load(f)
+        after_cats = sorted(
+            (c['slug'], c['name'], c.get('description', ''))
+            for c in adapter.cats.values()
+        )
+        base_cats = sorted(
+            (c['slug'], c['name'], c.get('description', ''))
+            for c in baseline['categories']
+        )
+        self.assertEqual(after_cats, base_cats)
+
+    def test_dry_run_makes_no_changes(self):
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.backup(self.backup)
+        adapter.set_logging(self.changes, self.terms)
+        adapter.create_category('X', 'x')
+        adapter.set_logging()
+
+        cats_before = dict(adapter.cats)
+        result = adapter.restore(
+            backup_path=self.backup,
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS,
+            dry_run=True,
+        )
+        self.assertTrue(result['dry_run'])
+        self.assertTrue(len(result['operations']) > 0)
+        # Cats unchanged.
+        self.assertEqual(set(adapter.cats.keys()), set(cats_before.keys()))
+
+    def test_update_cat_after_slug_rename(self):
+        """Codex fix #2: UPDATE_CAT should use term_id for robust lookup."""
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.set_logging(terms_log_path=self.terms)
+
+        # Rename slug AND update description in one call — produces two
+        # log rows both tagged with the old slug.
+        adapter.update_category(2, {'slug': 'technology', 'description': 'new'})
+        adapter.set_logging()
+
+        # Write an empty changes log so both logs exist for auto mode.
+        with open(self.changes, 'w') as f:
+            f.write('')
+
+        result = adapter.restore(
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS,
+            dry_run=False,
+        )
+        self.assertFalse(result['errors'])
+        self.assertEqual(adapter.cats[2]['slug'], 'tech')
+        self.assertEqual(adapter.cats[2]['description'], 'old desc')
+
+    def test_hierarchy_restored_after_delete(self):
+        """Codex fix (parent-ID mapping): deleted child gets correct parent."""
+        cats = {
+            10: {'ID': 10, 'name': 'Parent', 'slug': 'parent',
+                 'description': '', 'parent': 0, 'post_count': 0},
+            20: {'ID': 20, 'name': 'Child', 'slug': 'child',
+                 'description': '', 'parent': 10, 'post_count': 0},
+        }
+        adapter = FakeWpcom(cats=cats, default_id=10)
+        adapter.set_logging(self.changes, self.terms)
+
+        adapter.set_default_category(20)
+        adapter.default_id = 20
+        adapter.delete_category(20)
+        adapter.delete_category(10)
+        adapter.set_logging()
+
+        result = adapter.restore(
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS,
+            dry_run=False,
+        )
+        self.assertFalse(result['errors'])
+        parent = next(
+            c for c in adapter.cats.values() if c['slug'] == 'parent'
+        )
+        child = next(
+            c for c in adapter.cats.values() if c['slug'] == 'child'
+        )
+        # Child's parent should be the recreated parent's new live ID.
+        self.assertEqual(child['parent'], parent['ID'])
+
+
+class TestRestoreFromSnapshot(unittest.TestCase):
+    """Tests for full-snapshot restore."""
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix='taxo-test-')
+        self.backup = os.path.join(self.workdir, 'backup.json')
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+
+    def test_round_trip(self):
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.backup(self.backup)
+
+        # Mutate without logging.
+        adapter.create_category('New', 'new')
+        adapter.update_category(2, {'description': 'changed'})
+
+        result = adapter.restore(
+            backup_path=self.backup, mode=MODE_SNAPSHOT, dry_run=False,
+        )
+        self.assertFalse(result['errors'])
+        self.assertEqual(result['mode'], MODE_SNAPSHOT)
+
+        with open(self.backup) as f:
+            baseline = json.load(f)
+        after_cats = sorted(c['slug'] for c in adapter.cats.values())
+        base_cats = sorted(c['slug'] for c in baseline['categories'])
+        self.assertEqual(after_cats, base_cats)
+
+    def test_hierarchy_reconciled(self):
+        """Codex fix #4: snapshot restore should fix parent-child."""
+        cats = _make_cats()
+        cats[2]['parent'] = 1  # Tech is child of General
+        adapter = FakeWpcom(cats=cats)
+        adapter.backup(self.backup)
+
+        adapter.update_category(2, {'parent': 0})
+        self.assertEqual(adapter.cats[2]['parent'], 0)
+
+        result = adapter.restore(
+            backup_path=self.backup, mode=MODE_SNAPSHOT, dry_run=False,
+        )
+        self.assertFalse(result['errors'])
+        self.assertEqual(adapter.cats[2]['parent'], 1)
+
+    def test_dry_run(self):
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.backup(self.backup)
+        adapter.create_category('New', 'new')
+        cats_before = set(adapter.cats.keys())
+
+        result = adapter.restore(
+            backup_path=self.backup, mode=MODE_SNAPSHOT, dry_run=True,
+        )
+        self.assertTrue(result['dry_run'])
+        self.assertEqual(set(adapter.cats.keys()), cats_before)
+
+
+class TestRestoreAutoMode(unittest.TestCase):
+    """Tests for mode=auto fallback behavior."""
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix='taxo-test-')
+        self.changes = os.path.join(self.workdir, 'changes.tsv')
+        self.terms = os.path.join(self.workdir, 'terms.tsv')
+        self.backup = os.path.join(self.workdir, 'backup.json')
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+
+    def test_both_logs_uses_log_mode(self):
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.backup(self.backup)
+        adapter.set_logging(self.changes, self.terms)
+        adapter.create_category('X', 'x')
+        adapter.set_post_categories(
+            123, [1], old_category_ids=[2], post_title='Hello',
+        )
+        adapter.set_logging()
+
+        result = adapter.restore(
+            backup_path=self.backup,
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            dry_run=True,
+        )
+        self.assertEqual(result['mode'], MODE_LOGS)
+
+    def test_one_log_falls_back_to_snapshot(self):
+        """Codex fix #1: partial logs → snapshot, not partial replay."""
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.backup(self.backup)
+        adapter.set_logging(self.changes, self.terms)
+        adapter.create_category('X', 'x')
+        adapter.set_logging()
+
+        # Only the terms log was written (no post changes were made).
+        # Confirm changes log does NOT exist — only terms does.
+        self.assertFalse(os.path.exists(self.changes))
+
+        result = adapter.restore(
+            backup_path=self.backup,
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            dry_run=True,
+        )
+        self.assertEqual(result['mode'], MODE_SNAPSHOT)
+        # Should contain a warning about the partial log.
+        warnings = [e for e in result['errors'] if e.get('op') is None]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('changes', warnings[0]['error'].lower())
+
+    def test_no_logs_no_backup_raises(self):
+        adapter = FakeWpcom(cats=_make_cats())
+        with self.assertRaises(ValueError):
+            adapter.restore()
 
 
 if __name__ == '__main__':

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -954,6 +954,70 @@ class TestPartialRestoreError(unittest.TestCase):
         self.assertFalse(result['partial'])
 
 
+class TestRestoreLog(unittest.TestCase):
+    """Tests for the streamed restore audit log."""
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp(prefix='taxo-test-')
+        self.changes = os.path.join(self.workdir, 'changes.tsv')
+        self.terms = os.path.join(self.workdir, 'terms.tsv')
+        self.backup = os.path.join(self.workdir, 'backup.json')
+        self.restore_log = os.path.join(self.workdir, 'restore.tsv')
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+
+    def test_restore_log_written_during_log_replay(self):
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.backup(self.backup)
+        adapter.set_logging(self.changes, self.terms)
+        adapter.create_category('X', 'x-cat')
+        adapter.set_post_categories(
+            123, [1], old_category_ids=[2], post_title='Hello',
+        )
+        adapter.set_logging()
+
+        adapter.restore(
+            backup_path=self.backup,
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS, dry_run=False,
+            restore_log_path=self.restore_log,
+        )
+        self.assertTrue(os.path.exists(self.restore_log))
+        with open(self.restore_log) as f:
+            lines = f.readlines()
+        # Header + at least 2 ops (SET_CATS + CREATE_CAT inverse).
+        self.assertGreaterEqual(len(lines), 3)
+        self.assertIn('kind', lines[0])  # header row
+
+    def test_restore_log_written_during_snapshot(self):
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.backup(self.backup)
+        adapter.create_category('X', 'x-cat')
+
+        adapter.restore(
+            backup_path=self.backup,
+            mode=MODE_SNAPSHOT, dry_run=False,
+            restore_log_path=self.restore_log,
+        )
+        self.assertTrue(os.path.exists(self.restore_log))
+        with open(self.restore_log) as f:
+            content = f.read()
+        self.assertIn('delete_category', content)
+
+    def test_no_restore_log_on_dry_run(self):
+        adapter = FakeWpcom(cats=_make_cats())
+        adapter.backup(self.backup)
+
+        adapter.restore(
+            backup_path=self.backup,
+            mode=MODE_SNAPSHOT, dry_run=True,
+            restore_log_path=self.restore_log,
+        )
+        self.assertFalse(os.path.exists(self.restore_log))
+
+
 class TestReadBackVerification(unittest.TestCase):
     """Tests for post-mutation read-back verification."""
 


### PR DESCRIPTION
Matt's https://ma.tt/2026/04/taxonomist/ flags that "logging and reverting still contain bugs." Taxonomist's core promise is "nothing is lost" — but until now, WordPress.com users had no working undo path. lib/restore.php only runs via WP-CLI; wpcom_adapter.py had a backup() method but no restore() counterpart.                                                        
                                                            
This PR closes that gap with three layers of change:                                                                                                                                    
                                                            
### 1. Term-operation logging (wpcom_adapter.py)                                                                                                                                            
                                                            
Every mutating call now appends to opt-in TSV logs (enabled via adapter.set_logging(changes_path, terms_path)):                                                                         
- changes-{ts}.tsv — post category assignments                                                                                                                                          
- terms-{ts}.tsv — category mutations (create/delete/update/set-default), with full pre-delete snapshots so deleted categories can be recreated exactly                                                                                                                                                               
                                                            
Microsecond timestamps preserve operation order within a single apply run.                                                                                                              
                                                            
### 2. Two-mode restore (wpcom_adapter.py)                                                                                                                                                  
                                                            
- Inverse replay (preferred) — reads both TSV logs, reverses them, and undoes only what Taxonomist actually did. Surgical and safe for sites edited outside Taxonomist between apply and revert.                                                  
- Snapshot restore (fallback) — rewrites the entire taxonomy from backup-{ts}.json. Works when logs are missing or corrupted.                                                           
                                                                                                                                                                                          
Both modes support dry_run=True so the restore agent can preview every operation before touching the site.                                                                              
                                                                                                                                                                                          
### 3. Restore agent (agents/restore.md)                                                                                                                                                    
                                                            
New first-class agent that locates a run by timestamp, dispatches by connection method (wp-cli → existing restore.php, wpcom → new adapter methods, rest-api/jwt/xmlrpc → clear "not yet supported" message), runs a dry-run preview, requires explicit user approval, executes, and verifies.
                                                                                                                                                                                          
### Key design decisions                                      

- Auto mode requires both logs for inverse replay. If only one log exists, falls back to snapshot with a warning — partial replay (e.g., undoing post assignments but leaving orphaned categories) is a data-integrity risk.
- set_post_categories enforces old_category_ids when logging is on. Raises ValueError if omitted, rather than silently logging an empty old_categories column that would cause revert to strip a post to zero categories.                                                                                                                                                       
- Category hierarchy is restored. Both restore modes resolve backup parent term_ids through slug → live ID mapping (mirroring restore.php's two-pass approach). Log replay builds an id_to_slug map from the term log so recreated categories get the correct live parent even when IDs shift.                                                                               
- Lookup by term_id first, slug as fallback. Handles the case where a single update_category call renames the slug and changes another field — both log rows reference the old slug, but term_id is stable across renames.                                                                                                                                                      
                                                            
### Files changed                                                                                                                                                                           
                                                            
- **lib/adapters/wpcom_adapter.py:** Logging hooks on all mutation methods, set_default_category(), restore() / restore_from_logs() / restore_from_snapshot(), helper consolidation (_find_category, _term_snapshot, _logging_suspended, action constants)  
- **lib/helpers.py:** parse_terms_log(), shared _read_tsv_dicts()                                                                                                        
- **agents/restore.md:** New restore agent 
- **agents/apply.md:** WordPress.com workflow now requires adapter calls (not raw curl) so writes can't bypass the logger                                                 
- **AGENTS.md:** Updated Change Logging and Reverting Changes sections                                                                                              
- **tests/test_wpcom_adapter.py:** 16 new tests (99 total, up from 83) covering logging, both restore modes, auto-mode fallback
  
### Out of scope                                                                                                                                                                            
                                                            
- rest-api / rest-api-jwt / xmlrpc adapter restore paths (those adapters don't exist yet — the agent surfaces a clear message)                                                          
- Fixing known bugs in lib/restore.php (collision-on-slug, orphaned temp names) — the new wpcom path doesn't reproduce them
- ThreadPoolExecutor for parallel post updates during snapshot restore (real win for large sites, worth a follow-up)