### PR TITLE
Close HTTPError in test to fix ResourceWarning

### DIFF
--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -334,6 +334,7 @@ class TestErrorHandling(unittest.TestCase):
         with self.assertRaises(WpcomApiError) as ctx:
             adapter.list_categories()
         self.assertEqual(ctx.exception.status_code, 500)
+        error.close()
 
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
     def test_connection_error_raised(self, mock_urlopen):


### PR DESCRIPTION
## Summary
- Close the `HTTPError` object in `test_http_error_raised` to prevent Python 3.14's `ResourceWarning` about implicit cleanup of the underlying `BytesIO` file pointer

## Test plan
- `python3 -m unittest discover tests` passes with 83 tests and no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)