### PR TITLE
Fix set_post_categories silent drop of numeric category names

### DIFF
--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -84,7 +84,8 @@ class WpcomAdapter:
 
     # --- HTTP layer ---
 
-    def _request(self, method, path, data=None, params=None):
+    def _request(self, method, path, data=None, params=None,
+                 override_url=None, json_body=None):
         """
         Make an authenticated request to the WordPress.com API.
 
@@ -93,6 +94,11 @@ class WpcomAdapter:
             path: API path (e.g., '/sites/{id}/categories').
             data: Dict of form data for POST requests.
             params: Dict of query parameters.
+            override_url: Full URL to use instead of BASE_URL + path.
+                For endpoints on a different API version (e.g., v1.2).
+                When set, `path` is ignored.
+            json_body: If set, send this dict as a JSON body instead of
+                form-urlencoded `data`. Mutually exclusive with `data`.
 
         Returns:
             Parsed JSON response as a dict.
@@ -100,19 +106,24 @@ class WpcomAdapter:
         Raises:
             WpcomApiError: On any API error (including 200 with error field).
         """
-        url = f'{self.BASE_URL}{path}'
+        url = override_url if override_url else f'{self.BASE_URL}{path}'
         if params:
             url += '?' + wp_urlencode(params)
 
         body = None
-        if data is not None:
+        content_type = None
+        if json_body is not None:
+            body = json.dumps(json_body).encode('utf-8')
+            content_type = 'application/json'
+        elif data is not None:
             body = wp_urlencode(data).encode('utf-8')
+            content_type = 'application/x-www-form-urlencoded'
 
         req = urllib.request.Request(url, data=body, method=method)
         req.add_header('Authorization', f'Bearer {self.access_token}')
         req.add_header('User-Agent', 'taxonomist/1.0')
         if body:
-            req.add_header('Content-Type', 'application/x-www-form-urlencoded')
+            req.add_header('Content-Type', content_type)
 
         try:
             with urllib.request.urlopen(req, timeout=30) as resp:
@@ -281,29 +292,74 @@ class WpcomAdapter:
         """
         Set categories for a post by term IDs.
 
-        Resolves IDs to names because the WP.com API accepts
-        comma-separated category names, not IDs.
+        Uses v1.2 + `categories_by_id` because the v1.1 + name-based
+        `categories` parameter silently drops numeric names (it
+        interprets them as term IDs and discards unknown ones). The
+        v1.1 vs v1.2 divergence and the sanctioned shape are
+        documented in PR #10; this method implements the rule in code.
 
         Args:
             post_id: Integer post ID.
             category_ids: List of integer category IDs.
 
         Raises:
-            WpcomApiError: If any category ID is not found.
+            WpcomApiError: If any category ID is not found in the
+                local cache, or if the API silently drops one of the
+                submitted IDs (a known `categories_by_id` silent
+                failure mode — see PR #10).
         """
-        names = []
+        # Validate every ID exists in the local category cache before
+        # we hit the remote endpoint. Unknown IDs would be silently
+        # dropped by `categories_by_id`, so catching them locally
+        # turns a silent failure into a loud one.
+        category_ids = [int(cid) for cid in category_ids]
         for cid in category_ids:
-            cat = self._get_category_by_id(cid)
-            if cat is None:
+            if self._get_category_by_id(cid) is None:
                 raise WpcomApiError(
                     404, 'not_found', f'Category ID {cid} not found',
                 )
-            names.append(cat['name'])
 
-        self._post(
-            f'/sites/{self.site_id}/posts/{post_id}',
-            data={'categories': ','.join(names)},
+        # v1.2 + categories_by_id is the only sanctioned shape for
+        # WP.com post category updates. Name-based v1.1 drops numeric
+        # names; name-based v1.2 creates junk categories literally
+        # named after the numeric value. See PR #10 for the test plan.
+        v1_2_url = (
+            f'https://public-api.wordpress.com/rest/v1.2'
+            f'/sites/{self.site_id}/posts/{post_id}'
         )
+        result = self._request(
+            'POST',
+            path='',
+            override_url=v1_2_url,
+            json_body={'categories_by_id': category_ids},
+        )
+
+        # Detect silent drops: compare returned category IDs against
+        # what we sent. PR #10 documents that `categories_by_id`
+        # silently drops unknown or stale IDs with no error, so the
+        # only reliable check is a read-back of the response.
+        returned_ids = set()
+        terms_cat = (result.get('terms') or {}).get('category') or {}
+        for cat in terms_cat.values():
+            if isinstance(cat, dict) and 'ID' in cat:
+                returned_ids.add(int(cat['ID']))
+        # Fallback: older shape under `categories` (name-keyed hash).
+        if not returned_ids:
+            for cat in (result.get('categories') or {}).values():
+                if isinstance(cat, dict) and 'ID' in cat:
+                    returned_ids.add(int(cat['ID']))
+
+        sent_ids = set(category_ids)
+        if sent_ids and returned_ids != sent_ids:
+            dropped = sorted(sent_ids - returned_ids)
+            extra = sorted(returned_ids - sent_ids)
+            raise WpcomApiError(
+                500, 'categories_drift',
+                f'set_post_categories(post_id={post_id}): sent '
+                f'{sorted(sent_ids)} but post ended with '
+                f'{sorted(returned_ids)} '
+                f'(dropped={dropped}, extra={extra})',
+            )
 
     def create_category(self, name, slug, description=''):
         """

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -222,28 +222,84 @@ class TestUpdateCategory(unittest.TestCase):
 
 
 class TestSetPostCategories(unittest.TestCase):
-    """Tests for setting post categories."""
+    """Tests for setting post categories.
+
+    The adapter uses v1.2 + `categories_by_id` to avoid the v1.1
+    silent-failure modes documented in PR #10: numeric category
+    names get auto-interpreted as term IDs and silently dropped,
+    and v1.2 + name-based `categories` creates junk categories
+    literally named after the numeric value. The only safe shape
+    is v1.2 + integer IDs.
+    """
 
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
-    def test_resolves_ids_to_names(self, mock_urlopen):
+    def test_posts_categories_by_id_to_v1_2(self, mock_urlopen):
+        """Verify the request shape: v1.2 URL + JSON body + integer IDs."""
         cats = [
             {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0},
             {'ID': 2, 'name': 'AI', 'slug': 'ai', 'parent': 0},
         ]
         mock_urlopen.side_effect = [
             _mock_response({'found': 2, 'categories': cats}),
-            _mock_response({'ID': 100}),  # post update
+            # Post update response with matching categories so drift
+            # detection passes.
+            _mock_response({
+                'ID': 100,
+                'terms': {'category': {
+                    'tech': {'ID': 1, 'slug': 'tech'},
+                    'ai': {'ID': 2, 'slug': 'ai'},
+                }},
+            }),
         ]
         adapter = WpcomAdapter(VALID_CONFIG)
         adapter.set_post_categories(100, [1, 2])
 
         post_call = mock_urlopen.call_args_list[1]
-        body = post_call[0][0].data.decode('utf-8')
-        # Should send comma-separated names, not IDs.
-        self.assertIn('categories=Tech', body)
+        req = post_call[0][0]
+        # Target URL must be v1.2, not v1.1.
+        self.assertIn('/rest/v1.2/', req.full_url)
+        # Body must be JSON with categories_by_id as an integer list.
+        body = json.loads(req.data.decode('utf-8'))
+        self.assertEqual(body, {'categories_by_id': [1, 2]})
+        # Content-Type must announce JSON.
+        self.assertEqual(req.get_header('Content-type'), 'application/json')
 
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
-    def test_unknown_id_raises(self, mock_urlopen):
+    def test_numeric_category_name_is_not_dropped(self, mock_urlopen):
+        """Regression: category named '24' must survive the round trip.
+
+        The v1.1 + form-encoded `categories` shape silently dropped
+        numeric names because WP.com auto-interpreted them as term
+        IDs. The v1.2 + `categories_by_id` shape sends the term ID
+        directly, so the name's textual content is irrelevant.
+        """
+        cats = [
+            {'ID': 23586, 'name': '24', 'slug': '24', 'parent': 0},
+            {'ID': 1030, 'name': 'Action', 'slug': 'action', 'parent': 0},
+        ]
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 2, 'categories': cats}),
+            _mock_response({
+                'ID': 100,
+                'terms': {'category': {
+                    '24': {'ID': 23586, 'slug': '24'},
+                    'action': {'ID': 1030, 'slug': 'action'},
+                }},
+            }),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        # Must not raise.
+        adapter.set_post_categories(100, [23586, 1030])
+
+        post_call = mock_urlopen.call_args_list[1]
+        body = json.loads(post_call[0][0].data.decode('utf-8'))
+        # Both IDs must be in the payload — 23586 (for the "24" cat)
+        # and 1030 (for "Action"). Neither should be stringified.
+        self.assertEqual(body['categories_by_id'], [23586, 1030])
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_unknown_id_raises_before_posting(self, mock_urlopen):
+        """Pre-flight check: unknown IDs must be caught locally."""
         mock_urlopen.return_value = _mock_response({
             'found': 0, 'categories': [],
         })
@@ -251,6 +307,57 @@ class TestSetPostCategories(unittest.TestCase):
         with self.assertRaises(WpcomApiError) as ctx:
             adapter.set_post_categories(100, [999])
         self.assertEqual(ctx.exception.status_code, 404)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_raises_on_silent_drop_from_api(self, mock_urlopen):
+        """If the API returns fewer categories than we sent, raise.
+
+        `categories_by_id` is documented (PR #10) to silently drop
+        stale or unknown IDs with no error and HTTP 200. The only
+        reliable check is a read-back of the response against what
+        we sent, which must raise if they don't match.
+        """
+        cats = [
+            {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0},
+            {'ID': 2, 'name': 'AI', 'slug': 'ai', 'parent': 0},
+        ]
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 2, 'categories': cats}),
+            # API returned only category 1; category 2 was silently
+            # dropped. The adapter must surface this as an error.
+            _mock_response({
+                'ID': 100,
+                'terms': {'category': {
+                    'tech': {'ID': 1, 'slug': 'tech'},
+                }},
+            }),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError) as ctx:
+            adapter.set_post_categories(100, [1, 2])
+        self.assertEqual(ctx.exception.error, 'categories_drift')
+        self.assertIn('dropped=[2]', str(ctx.exception))
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_accepts_legacy_categories_response_shape(self, mock_urlopen):
+        """Fallback: some responses key category info under `categories`
+        (name-keyed hash) instead of `terms.category` (slug-keyed)."""
+        cats = [
+            {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0},
+        ]
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1, 'categories': cats}),
+            _mock_response({
+                'ID': 100,
+                'categories': {
+                    'Tech': {'ID': 1, 'slug': 'tech'},
+                },
+            }),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        # Must not raise — drift detection should find the match in
+        # the legacy shape.
+        adapter.set_post_categories(100, [1])
 
 
 class TestExportPosts(unittest.TestCase):


### PR DESCRIPTION
## Summary

- `set_post_categories` silently dropped any category whose name is purely numeric (e.g. "24", "1997") because v1.1's name-based `categories` parameter auto-interprets numeric tokens as term IDs and discards unknown ones with HTTP 200.
- Switches to v1.2 + `categories_by_id` (the shape #10 documents as the only sanctioned one for WP.com post category updates) and adds drift detection so the other silent failure mode — stale/unknown IDs getting dropped — also surfaces loudly.

## Why

This came out of end-to-end testing on a real WP.com site that happened to have a TV-show category literally named "24". After an apply run, the live "24" category had 0 members despite 72 posts having been updated to include it. No errors, no warnings — every call returned 200. The change log correctly recorded `new_categories: 24|Action|Drama`, but the live post state was just `[Action, Drama]`.

The underlying issue is a v1.1 vs v1.2 API divergence that #10 identified while reviewing #4:

- **v1.1** treats numeric values in `categories` as term IDs. Unknown IDs silently dropped.
- **v1.2** treats numeric values in `categories` as names. Creates junk categories literally named after the number.
- **v1.2 `categories_by_id`** takes integer IDs in a JSON body. True replace, no ambiguity.

#10 is documentation-only — it specified the rule in `AGENTS.md` and `agents/apply.md` but left the adapter code alone. This PR implements the rule in `wpcom_adapter.py`.

## What changed

**`_request`** gains two optional kwargs:
- `override_url` — full URL to use instead of `BASE_URL + path`, so one call can target v1.2 without migrating every other endpoint
- `json_body` — dict to send as a JSON body instead of form-urlencoded `data`

**`set_post_categories`** now:
1. Pre-validates every submitted ID against the local category cache (catches unknown IDs locally, turning a silent remote drop into a loud local error)
2. POSTs to `rest/v1.2/sites/{id}/posts/{id}` with `{"categories_by_id": [int, int, ...]}` as JSON
3. Reads back the response and compares returned category IDs to what was sent
4. Raises `WpcomApiError(500, 'categories_drift', ...)` if they don't match, catching the second silent-failure mode #10 warned about

Both the `terms.category` (slug-keyed, preferred) and legacy `categories` (name-keyed) response shapes are handled.

## Tests

Four new tests in `TestSetPostCategories`, plus one renamed. All 28 tests in `test_wpcom_adapter.py` pass.

- `test_posts_categories_by_id_to_v1_2` — verifies the request shape (v1.2 URL, JSON body, integer IDs, correct Content-Type)
- `test_numeric_category_name_is_not_dropped` — regression test for the actual bug, using a category named "24"
- `test_unknown_id_raises_before_posting` — pre-flight validation
- `test_raises_on_silent_drop_from_api` — drift detection: if the API returns fewer categories than sent, raise
- `test_accepts_legacy_categories_response_shape` — fallback for the older response shape

## Test plan

- [x] `python3 -m unittest tests.test_wpcom_adapter` — all 28 tests pass locally
- [x] Verified on a real WP.com site: direct call to the updated adapter attached the "24" category to a post that previously had it silently dropped
- [ ] Reviewer: confirm the v1.2 endpoint shape against #10's test plan

## Scope

Just `set_post_categories`. Does not touch any other adapter method, any agent markdown, or any other file. Can land independently of #19 (revert) — they don't conflict.

## Related

- #10 — documented the rule this PR implements
- #4 — the PR that surfaced the v1.1/v1.2 divergence in the first place