### PR TITLE
Fix backup() silently truncating at 100 posts

### DIFF
--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -445,30 +445,44 @@ class WpcomAdapter:
         """
         categories = self.list_categories()
 
-        # Get post-category mappings.
+        # Get post-category mappings. Uses offset pagination because
+        # WP.com v1.1 does not return `meta.next_page` for the posts
+        # endpoint — a page_handle-based loop silently truncates to
+        # the first 100 posts on every site. Offset is less elegant
+        # but is the shape the v1.1 endpoint actually supports.
         post_categories = []
-        page_handle = None
+        seen_ids = set()
+        offset = 0
         while True:
-            params = {
+            resp = self._get(f'/sites/{self.site_id}/posts', params={
                 'number': 100,
+                'offset': offset,
                 'status': 'publish',
                 'fields': 'ID,title,categories',
-            }
-            if page_handle:
-                params['page_handle'] = page_handle
-            resp = self._get(f'/sites/{self.site_id}/posts', params=params)
-            for post in resp.get('posts', []):
+            })
+            batch = resp.get('posts') or []
+            if not batch:
+                break
+            new_in_batch = 0
+            for post in batch:
+                post_id = post['ID']
+                # Offset pagination can return duplicates at page
+                # boundaries if the underlying query shifts between
+                # calls. Dedupe so the backup stays stable.
+                if post_id in seen_ids:
+                    continue
+                seen_ids.add(post_id)
+                new_in_batch += 1
                 cat_hash = post.get('categories') or {}
                 post_categories.append({
-                    'post_id': post['ID'],
+                    'post_id': post_id,
                     'post_title': post.get('title', ''),
                     'category_ids': [v['ID'] for v in cat_hash.values()],
                     'category_slugs': [v.get('slug', '') for v in cat_hash.values()],
                 })
-            meta = resp.get('meta', {})
-            page_handle = meta.get('next_page')
-            if not page_handle or not resp.get('posts'):
+            if new_in_batch == 0:
                 break
+            offset += 100
 
         # Resolve default category slug. Only suppress 404 (category
         # genuinely missing); all other errors should propagate.

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -383,7 +383,14 @@ class TestGetDefaultCategory(unittest.TestCase):
 
 
 class TestBackup(unittest.TestCase):
-    """Tests for full taxonomy backup."""
+    """Tests for full taxonomy backup.
+
+    The posts fetch uses offset pagination because WP.com v1.1 does
+    not return `meta.next_page` for the posts endpoint. The older
+    page_handle-based loop silently stopped after 100 posts on every
+    site — verified empirically on a real 766-post site where the
+    generated backup had `total_posts: 100`.
+    """
 
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
     def test_writes_backup_json(self, mock_urlopen):
@@ -396,8 +403,10 @@ class TestBackup(unittest.TestCase):
         mock_urlopen.side_effect = [
             # list_categories
             _mock_response({'found': 1, 'categories': [cat]}),
-            # posts pagination
-            _mock_response({'found': 1, 'posts': [post], 'meta': {}}),
+            # posts offset=0 — one post
+            _mock_response({'found': 1, 'posts': [post]}),
+            # posts offset=100 — empty, loop exits
+            _mock_response({'found': 1, 'posts': []}),
             # get_default_category -> settings
             _mock_response({'default_category': 1}),
             # get_default_category -> category cache
@@ -416,6 +425,121 @@ class TestBackup(unittest.TestCase):
             self.assertEqual(backup['default_category_slug'], 'tech')
             self.assertEqual(backup['categories'][0]['term_id'], 1)
             self.assertEqual(backup['post_categories'][0]['post_id'], 100)
+        finally:
+            os.unlink(output_path)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_paginates_through_multiple_pages(self, mock_urlopen):
+        """Regression: every post beyond the first page must be captured.
+
+        The previous page_handle-based loop read `meta.next_page`
+        which WP.com v1.1 does not return, so the backup silently
+        truncated at 100 posts. This test builds a 250-post response
+        and asserts all 250 end up in the backup.
+        """
+        cat = {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0,
+               'description': '', 'post_count': 250}
+
+        def _page(start, count):
+            return [
+                {
+                    'ID': start + i,
+                    'title': f'Post {start + i}',
+                    'categories': {'Tech': {'ID': 1, 'slug': 'tech'}},
+                }
+                for i in range(count)
+            ]
+
+        mock_urlopen.side_effect = [
+            # list_categories
+            _mock_response({'found': 1, 'categories': [cat]}),
+            # posts offset=0 — 100 posts
+            _mock_response({'found': 250, 'posts': _page(1, 100)}),
+            # posts offset=100 — 100 posts
+            _mock_response({'found': 250, 'posts': _page(101, 100)}),
+            # posts offset=200 — 50 posts
+            _mock_response({'found': 250, 'posts': _page(201, 50)}),
+            # posts offset=300 — empty, loop exits
+            _mock_response({'found': 250, 'posts': []}),
+            # get_default_category -> settings
+            _mock_response({'default_category': 1}),
+            # get_default_category -> category cache
+            _mock_response({'found': 1, 'categories': [cat]}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.backup(output_path)
+            with open(output_path) as f:
+                backup = json.load(f)
+            self.assertEqual(backup['total_posts'], 250)
+            ids = [p['post_id'] for p in backup['post_categories']]
+            self.assertEqual(ids, list(range(1, 251)))
+        finally:
+            os.unlink(output_path)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_sends_offset_not_page_handle(self, mock_urlopen):
+        """The posts query must use `offset`, not `page_handle`."""
+        cat = {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0,
+               'description': '', 'post_count': 0}
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1, 'categories': [cat]}),
+            _mock_response({'found': 0, 'posts': []}),
+            _mock_response({'default_category': 1}),
+            _mock_response({'found': 1, 'categories': [cat]}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.backup(output_path)
+            # Second call is the first posts page.
+            posts_url = mock_urlopen.call_args_list[1][0][0].full_url
+            self.assertIn('offset=0', posts_url)
+            self.assertNotIn('page_handle', posts_url)
+        finally:
+            os.unlink(output_path)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_dedupes_across_page_boundaries(self, mock_urlopen):
+        """Offset pagination can return the same post twice if the
+        underlying query shifts (e.g., a new post is published between
+        pages). The loop must dedupe and still terminate."""
+        cat = {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0,
+               'description': '', 'post_count': 3}
+
+        def _post(pid):
+            return {
+                'ID': pid,
+                'title': f'Post {pid}',
+                'categories': {'Tech': {'ID': 1, 'slug': 'tech'}},
+            }
+
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1, 'categories': [cat]}),
+            # offset=0 — posts 1, 2, 3
+            _mock_response({'found': 3, 'posts': [_post(1), _post(2), _post(3)]}),
+            # offset=100 — same posts again (simulates shifted query).
+            # No new IDs, loop must exit rather than spin forever.
+            _mock_response({'found': 3, 'posts': [_post(1), _post(2), _post(3)]}),
+            _mock_response({'default_category': 1}),
+            _mock_response({'found': 1, 'categories': [cat]}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.backup(output_path)
+            with open(output_path) as f:
+                backup = json.load(f)
+            # Each post appears exactly once.
+            ids = [p['post_id'] for p in backup['post_categories']]
+            self.assertEqual(sorted(ids), [1, 2, 3])
+            self.assertEqual(backup['total_posts'], 3)
         finally:
             os.unlink(output_path)
 


### PR DESCRIPTION
## What this fixes

`backup()` currently paginates through the posts endpoint by reading `meta.next_page` off each response and feeding it back in as a `page_handle` parameter. WP.com's v1.1 posts endpoint does not return `meta.next_page` though — the meta object is just `{"links": {...}, "wpcom": true}` — so `page_handle` is always `None` and the loop exits after the first page.

Result: on any site with more than 100 posts, the backup is silently truncated to the first 100. The file reports `total_posts: 100` regardless of the site's actual size, and every post beyond the first page is absent from `backup['post_categories']`.

I ran into this during the end-to-end test of #19 on a 766-post site. The adapter happily wrote `backup-{timestamp}.json` with `total_posts: 100`; the other 666 posts had no backup representation at all. No errors, no warnings, nothing in logs. The backup file looked completely normal until I started comparing it against my independent export of the same site.

## Why this matters

Log-mode restore happens to mask this bug because it reads the change log, not the backup. That's why I didn't notice during the actual revert of #19 — the inverse replay had all the info it needed from the TSV logs.

Snapshot-mode restore is a different story. That's the fallback that runs when the change logs are missing, corrupted, or when the user explicitly asks for a full rewrite. It iterates `backup['post_categories']` — so on a truncated backup, it would silently fail to restore 666 out of 766 posts on the same site without raising a single error. That's a data-loss hazard for the one code path the backup exists to enable.

## What changed

One method, one block. `backup()` now:

1. Uses **offset-based pagination** (`offset=0, 100, 200, ...`), which v1.1 supports reliably. Same shape everything else on WP.com v1.1 uses.
2. **Dedupes posts by ID** across pages, because offset pagination can return the same post twice if a post is added between pages and shifts the underlying query.
3. **Exits on empty batch OR no-new-IDs batch** — the second condition prevents an infinite loop if the query gets stuck returning the same IDs over and over.

Nothing else in `backup()` changes; `list_categories`, default category resolution, and the JSON shape are all untouched. Fix is purely in the pagination loop.

## Tests

Three new tests in `TestBackup` plus one updated (the existing `test_writes_backup_json` now mocks the empty second page that the offset loop needs to exit). All 28 tests pass.

- `test_paginates_through_multiple_pages` — regression: mocks a 250-post response across 3 pages and asserts all 250 end up in the backup with their IDs intact
- `test_sends_offset_not_page_handle` — verifies the query uses `offset=0` and does not include `page_handle` (so a future refactor that accidentally reverts the pagination mechanism gets caught)
- `test_dedupes_across_page_boundaries` — mocks two pages returning the same three posts and asserts each is captured exactly once, and the loop terminates

## Test plan

- [x] `python3 -m unittest tests.test_wpcom_adapter` passes all 28 tests
- [x] Verified empirically during #19 testing: a 766-post site generates a backup with 100 entries on `main`; verified locally that the fix captures all 766 (though the unit tests cover the mechanism)
- [ ] Reviewer: sanity check the dedupe loop termination condition on a site with exactly 100 posts

## Scope

Just `backup()`. Nothing else in the adapter, no agent markdown, no tests for anything else. Can land independently of #19 and #21 — none of them touch this code path.

That said, this one is arguably the most urgent of the adapter bugs I found during #19 testing, because a truncated backup is a silent snapshot-restore data loss waiting to happen. If #19 lands with snapshot-mode exercised, this bug becomes user-visible immediately.

## Related

- #19 — end-to-end test that turned up this bug
- #21 — the other adapter fix from the same test run (independent scope)