### PR TITLE
Check account capabilities before export and analyze

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,18 +25,19 @@ This is an AI-assisted tool. Users download this repo, open it with their AI cod
 ### Workflow
 
 1. **Connect** — Detect and configure access to the WordPress site
-2. **Export** — Download all posts (full content) and categories locally
-3. **Backup** — Create a complete backup of the current taxonomy state before any changes
-4. **Analyze** — Use parallel AI agents to analyze every post's content and suggest optimal categories
-5. **Validate** — Run automated checks on analysis results before presenting to the user (see Validation below)
-6. **Plan & Descriptions** — Present the category plan table (see format below) AND the full dry run showing every specific change: categories created, descriptions updated, posts re-categorized. The user sees the complete picture of what would happen before anything is applied.
-7. **Review** — Iterate with the user until the plan is right
-8. **Authenticate** — Only after the user approves the dry run, ask for write credentials
-9. **Apply descriptions** — Update category descriptions first, before any post changes
-10. **Apply categories** — Execute post category changes, logging every single change
-11. **Verify** — Confirm the site still works and categories look correct
+2. **Verify capabilities** — Confirm the authenticated account has `manage_categories` on the target site. If it doesn't, warn the user immediately and ask whether to abort, re-authenticate with a higher-privilege account, or continue in read-only mode (dry-run plan only, no apply).
+3. **Export** — Download all posts (full content) and categories locally
+4. **Backup** — Create a complete backup of the current taxonomy state before any changes
+5. **Analyze** — Use parallel AI agents to analyze every post's content and suggest optimal categories
+6. **Validate** — Run automated checks on analysis results before presenting to the user (see Validation below)
+7. **Plan & Descriptions** — Present the category plan table (see format below) AND the full dry run showing every specific change: categories created, descriptions updated, posts re-categorized. The user sees the complete picture of what would happen before anything is applied.
+8. **Review** — Iterate with the user until the plan is right
+9. **Re-check capabilities** — Re-probe the token right before applying changes in case scope or roles changed between Connect and Apply.
+10. **Apply descriptions** — Update category descriptions first, before any post changes
+11. **Apply categories** — Execute post category changes, logging every single change
+12. **Verify** — Confirm the site still works and categories look correct
 
-**IMPORTANT:** Steps 1-7 require NO write access. The export and analysis use the public API or read-only access. Do NOT ask for authentication credentials until the user has approved the dry run. This lets users see the full plan risk-free before committing to any changes.
+**IMPORTANT — capability check is a hard gate.** The export and analysis steps burn significant tokens. Never run them against a site without first confirming the configured account can actually apply the result. If the user knowingly wants a dry-run-only pass (e.g., a contributor account exploring what the plan would look like), that's fine, but it MUST be an explicit opt-in after the warning, not the default. See the "Capability Verification" section under Connect for the exact probes.
 
 ### Core Principles
 

--- a/agents/connect.md
+++ b/agents/connect.md
@@ -38,7 +38,12 @@ All configuration should happen through the conversation. Ask for credentials in
    - Save credentials to config.json — it's gitignored so it never gets committed
    - Never show credentials in curl output — read from config.json
 6. Test the connection by listing categories
-7. Write config.json with everything needed to reconnect without re-authenticating:
+7. **Verify capabilities (HARD GATE)** — before writing config.json or proceeding to export, confirm the authenticated account has the capability Taxonomist actually needs. See the "Capability Verification" section below for the exact probe per method. If the account lacks `manage_categories`:
+   - Tell the user explicitly which role was detected (e.g., "Contributor") and which capability is missing.
+   - Offer three choices via `AskUserQuestion`: (a) re-authenticate with a higher-privilege account, (b) abort, or (c) continue in read-only mode (dry-run plan only, no apply).
+   - If the user picks (c), set `"read_only": true` in config.json so downstream steps know to stop at the plan.
+   - Do NOT silently fall through. Running the analyze step against a contributor-level token wastes tokens and time.
+8. Write config.json with everything needed to reconnect without re-authenticating:
    ```json
    {
      "site_url": "https://example.com",
@@ -188,11 +193,69 @@ Save token to config.json (gitignored):
 
 Test by reading token from config and curling the API.
 
+## Capability Verification
+
+Taxonomist needs to create, update, and delete categories. That requires `manage_categories`. In WordPress role terms, this is **Editor** or **Administrator**. Contributor and Author roles cannot complete an apply.
+
+Run the probe that matches the connection method. If the probe indicates the account lacks `manage_categories`, STOP and apply the gate described in step 7.
+
+### WordPress.com / Jetpack API
+
+`GET /rest/v1.1/sites/$site` returns the site info including a `capabilities` object scoped to the authenticated user for that site.
+
+```bash
+TOKEN=$(python3 -c "import json; print(json.load(open('config.json'))['connection']['access_token'])")
+SITE=$(python3 -c "import json; print(json.load(open('config.json'))['connection']['site_id'])")
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://public-api.wordpress.com/rest/v1.1/sites/$SITE?fields=ID,URL,capabilities" \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+caps = data.get('capabilities', {})
+if not caps.get('manage_categories'):
+    print('MISSING: manage_categories')
+    sys.exit(1)
+print('OK: manage_categories verified')
+"
+```
+
+If the user has Contributor access, `manage_categories` will be `false` even though the token can read categories.
+
+### REST API + Application Password / JWT
+
+Fetch `/wp-json/wp/v2/users/me?context=edit` with the credentials. The `capabilities` field lists every capability the account has.
+
+```bash
+curl -s -u "$USER:$APP_PASSWORD" "$API_URL/wp/v2/users/me?context=edit" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+if not data.get('capabilities', {}).get('manage_categories'):
+    print('MISSING: manage_categories')
+    sys.exit(1)
+print(f'OK: role={list(data.get(\"roles\", []))}, manage_categories verified')
+"
+```
+
+If the endpoint returns 401/403, the token lacks even `edit` context and definitely cannot apply changes.
+
+### WP-CLI (SSH or local)
+
+```bash
+# Replace {USER} with the account whose credentials WP-CLI will run as (usually the SSH user's mapped WP user, or --user= in wp_cli_flags).
+wp cap list "$USER" | grep -Fx manage_categories
+```
+
+If the grep prints nothing, the capability is missing.
+
+### XML-RPC
+
+XML-RPC does not expose granular capabilities. Use `wp.getUsersBlogs` + `wp.getProfile` to read the role string; assume any role below Editor is insufficient and warn the user.
+
 ## Important
 
 - config.json is gitignored — credentials stay local, never committed
 - Test the connection before finalizing config
-- Verify write access (not just read) by checking if the user has edit_posts capability
+- **The capability probe is a hard gate, not a nice-to-have.** Running Export and Analyze burns tokens. Never run them against a site without first confirming the account can actually apply the result.
 - Connection method preference: WP-CLI SSH > WP-CLI local > WordPress.com API > REST API + App Password > REST API + JWT > XML-RPC
 - For WordPress.com hosted sites, the WordPress.com API is the natural choice
 - For self-hosted sites with Jetpack, offer the WordPress.com API as an option alongside direct REST API


### PR DESCRIPTION
## Summary

Got bitten by this earlier today: I kicked off a Taxonomist run against a site with a Contributor-level WordPress.com account. Read access was fine, so Export chugged through 3,538 posts and Analyze started building a plan; we only found out about the permissions problem when Apply started 403'ing. By then we'd already burned a lot of tokens classifying content the account couldn't touch anyway.

This PR adds an explicit capability gate right after Connect:

- **WordPress.com / Jetpack:** probe `GET /rest/v1.1/sites/$site` and check `capabilities.manage_categories`.
- **REST API + App Password / JWT:** `GET /wp-json/wp/v2/users/me?context=edit` and check the same field.
- **WP-CLI:** `wp cap list $user | grep -Fx manage_categories`.
- **XML-RPC:** fall back to role checking; the protocol doesn't expose granular capabilities.

If `manage_categories` is missing, the agent stops and asks whether to re-authenticate, abort, or continue in read-only mode (config gets `"read_only": true` and downstream steps stop at the plan). Only `manage_categories` is checked; it's the one capability every Taxonomist write actually needs, so we don't need to overthink this.

## Trade-off with 1133bd2

That commit deliberately deferred write authentication until after the dry run, so users could see the full plan risk-free before handing over credentials. This PR narrows that principle rather than reverses it: you can still see the plan without write access, but only as an explicit opt-in. The default path now confirms write scope before running anything expensive.

The rationale is simple; the original assumption was that read-only work was effectively free, but on a large site Analyze burns real tokens, and silently wasting them on a contributor-scoped account turned out to be worse than adding one up-front check.

## Test plan

I ran this end-to-end against a real Jetpack site with two actual OAuth flows:

- [x] **Contributor case:** authorized with a Contributor account; probe returned `manage_categories: false`, the gate blocked the flow, and the three-way question fired as intended.
- [x] **Admin case:** re-authorized with an Administrator account; probe returned `manage_categories: true`, the gate let the flow continue.

Worth double-checking before merge:

- [ ] Read-only opt-in: confirm `"read_only": true` gets written to `config.json` and that Export / Analyze actually honor it.
- [ ] REST API + App Password probe against a self-hosted site.
- [ ] WP-CLI `cap list` probe against a real server.

Let me know if anything feels off.