### PR TITLE
Fix find_incomplete_batches treating valid results as incomplete

### DIFF
--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -228,7 +228,7 @@ def find_incomplete_batches(batch_dir, results_dir):
         try:
             with open(result_path) as f:
                 data = json.load(f)
-            if validate_suggestions(data):
+            if not validate_suggestions(data)['valid']:
                 # Validation errors — treat as incomplete.
                 incomplete.append(batch_file)
                 continue

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -269,7 +269,6 @@ class TestAggregateResults(unittest.TestCase):
             result = aggregate_results(tmpdir)
             suggestions = result['suggestions']
             cat_counts = result['category_counts']
-            new_counts = result['new_category_counts']
             self.assertEqual(len(suggestions), 0)
             self.assertEqual(len(cat_counts), 0)
 
@@ -392,7 +391,9 @@ class TestValidateExport(unittest.TestCase):
         ]
         result = validate_export(posts)
         self.assertFalse(result['valid'])
-        self.assertTrue(any('"categories" must contain only strings' in e for e in result['errors']))
+        self.assertTrue(
+            any('"categories" must contain only strings' in e for e in result['errors'])
+        )
 
 
 class TestValidateSuggestions(unittest.TestCase):

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -21,10 +21,16 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
 from adapters.wpcom_adapter import (
-    WpcomAdapter, WpcomApiError, PartialRestoreError, wp_urlencode,
-    ACTION_CREATE_CAT, ACTION_DELETE_CAT, ACTION_UPDATE_CAT,
-    ACTION_SET_CATS, ACTION_SET_DEFAULT,
-    MODE_AUTO, MODE_LOGS, MODE_SNAPSHOT,
+    ACTION_CREATE_CAT,
+    ACTION_DELETE_CAT,
+    ACTION_SET_CATS,
+    ACTION_SET_DEFAULT,
+    MODE_LOGS,
+    MODE_SNAPSHOT,
+    PartialRestoreError,
+    WpcomAdapter,
+    WpcomApiError,
+    wp_urlencode,
 )
 
 VALID_CONFIG = {


### PR DESCRIPTION
## Summary

`find_incomplete_batches()` was flagging every batch with a valid result file as incomplete, breaking the resume-after-interrupt path and three regression tests in `tests/test_helpers.py::TestFindIncompleteBatches` (`test_all_complete`, `test_gap_in_middle`, `test_extra_result_ids_still_valid`).

## Root cause

[`85ca9b1`](../commit/85ca9b1) (PR #13, "Standardize helper return types") changed `validate_suggestions()` from returning a list of error strings to returning `{'valid': bool, 'errors': [...]}`. The caller inside `find_incomplete_batches()` was missed:

```python
if validate_suggestions(data):
    # Validation errors — treat as incomplete.
    incomplete.append(batch_file)
    continue
```

A non-empty dict is always truthy, so the branch fired on every result file. The test suite has expected the corrected behavior since #13 landed — they've been red on `main` ever since.

## Fix

One line: check the dict's `valid` key instead.

```python
if not validate_suggestions(data)['valid']:
```

## Test plan

- [x] Three previously-failing tests in `TestFindIncompleteBatches` now pass.
- [x] Full `python3 -m unittest discover tests` suite: 137/137 green.
- [x] No other caller of `validate_suggestions()` needed updating (grep confirms).