### PR TITLE
Fix validate_result_ids crash on batch-manifest.json

### DIFF
--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -543,6 +543,10 @@ def validate_result_ids(results_dir, batch_dir):
     for filename in sorted(os.listdir(batch_dir)):
         if not (filename.startswith('batch-') and filename.endswith('.json')):
             continue
+        # write_batches() drops a dict-shaped batch-manifest.json in the
+        # same directory; it is not a post list, so skip it.
+        if filename == 'batch-manifest.json':
+            continue
         with open(os.path.join(batch_dir, filename)) as f:
             for post in json.load(f):
                 pid = post.get('post_id')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1150,6 +1150,33 @@ class TestValidateResultIds(unittest.TestCase):
             self.assertTrue(check['valid'])
             self.assertEqual(len(check['suspect_index_files']), 0)
 
+    def test_ignores_batch_manifest(self):
+        """The manifest write_batches() leaves in the batch dir must be
+        skipped, not parsed as a batch (it's a dict, not a post list)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_json(tmpdir, 'batches', 'batch-000.json', [
+                {'post_id': 100, 'title': 'A'},
+                {'post_id': 200, 'title': 'B'},
+            ])
+            # write_batches() always drops this dict-shaped manifest into
+            # the batch directory; validate_result_ids must not choke on it.
+            self._write_json(tmpdir, 'batches', 'batch-manifest.json', {
+                'fingerprint': 'abc',
+                'batch_size': 2,
+                'num_batches': 1,
+            })
+            self._write_json(tmpdir, 'results', 'result-000.json', [
+                {'post_id': 100, 'cats': ['tech']},
+                {'post_id': 200, 'cats': ['food']},
+            ])
+            check = validate_result_ids(
+                os.path.join(tmpdir, 'results'),
+                os.path.join(tmpdir, 'batches'),
+            )
+            self.assertTrue(check['valid'])
+            self.assertEqual(len(check['invalid_ids']), 0)
+            self.assertEqual(len(check['missing_ids']), 0)
+
 
 class TestValidateCategorySlugs(unittest.TestCase):
     """Tests for category slug validation in suggestions."""


### PR DESCRIPTION
While reviewing the codebase I ran into a crash in one of our own safety checks, so here's the first of a few small fixes I'll send one at a time.

`write_batches()` always writes a `batch-manifest.json` into the batch directory. `validate_result_ids()` scanned every `batch-*.json` file and iterated each one as a list of post dicts, but the manifest is a dict, so iterating it yielded the dict's string keys and the check died with `AttributeError: 'str' object has no attribute 'get'`.

AGENTS.md treats this validation as a hard gate before any category changes get applied; it's what catches the index-vs-ID bug, where an analyze agent emits array indices instead of real post IDs. Because `write_batches()` always leaves a manifest behind, the gate crashed on every real run.

The fix just skips `batch-manifest.json`, the same way `find_incomplete_batches()` already does. I also added a regression test that drops a manifest into the batch dir so it can't sneak back.

### Testing
- `python3 -m unittest discover tests` — green (the new test fails without the fix, passes with it)
- `ruff check lib/ tests/` — clean

Of note: I found this during a full-codebase review and have a handful of related fixes queued; I'm sending them one PR at a time so each is easy to review on its own. :)
