### PR TITLE
Guard set_post_categories against empty-list category wipe

### DIFF
--- a/agents/apply.md
+++ b/agents/apply.md
@@ -150,7 +150,9 @@ names drift when a category is renamed upstream of the call.
   reassigns the post to the site's default category (e.g. `Uncategorized`).
   Never send an empty array unless you explicitly intend to clear.
   Taxonomist should treat an empty `cats` list from analysis as a bug,
-  not a pass-through.
+  not a pass-through. `WpcomAdapter.set_post_categories()` enforces this:
+  it raises `ValueError` on an empty list unless you pass
+  `allow_clear=True` (reserved for intentional clears such as restore).
 - **Unknown IDs are silently dropped, not errored.** If you send
   `{"categories_by_id": [1030, 999999999]}`, the API returns HTTP 200
   and applies only the IDs that exist (`[1030]` in this example). There

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -463,7 +463,8 @@ class WpcomAdapter:
             json.dump(all_posts, f, ensure_ascii=False)
 
     def set_post_categories(self, post_id, category_ids,
-                            old_category_ids=None, post_title=''):
+                            old_category_ids=None, post_title='',
+                            allow_clear=False):
         """
         Set categories for a post by term IDs.
 
@@ -482,14 +483,22 @@ class WpcomAdapter:
                 we never spend an extra GET to recover it. When logging
                 is off this argument is ignored.
             post_title: Optional title for the log row (display only).
+            allow_clear: When False (default), an empty category_ids list
+                raises ValueError. WP.com treats `categories_by_id: []` as
+                a wipe (the post falls back to the site default), and an
+                empty list from analysis is a bug, not a pass-through (see
+                agents/apply.md). Set True only when intentionally clearing
+                a post (e.g. snapshot restore reverting a post that had no
+                categories at backup time).
 
         Raises:
             WpcomApiError: If any category ID is not found in the
                 local cache, or if the API silently drops one of the
                 submitted IDs (a known `categories_by_id` silent
                 failure mode — see PR #10).
-            ValueError: If logging is enabled but old_category_ids is
-                not supplied (would produce an unrevertable log row).
+            ValueError: If category_ids is empty and allow_clear is False,
+                or if logging is enabled but old_category_ids is not
+                supplied (would produce an unrevertable log row).
         """
         # Normalize, then resolve every ID to its name. _resolve_id_to_name
         # raises 404 for unknown IDs, which doubles as the local validation
@@ -497,6 +506,17 @@ class WpcomAdapter:
         # silently drops unknown IDs, so catching them locally turns a
         # silent failure into a loud one.
         category_ids = [int(cid) for cid in category_ids]
+        # An empty list wipes the post's categories. Refuse it unless the
+        # caller explicitly opts in, so a stray empty `cats` from analysis
+        # can't silently strip a post down to the default category.
+        if not category_ids and not allow_clear:
+            raise ValueError(
+                f'set_post_categories(post_id={post_id}): refusing to set '
+                'an empty category list. WordPress.com treats this as a '
+                'wipe (the post falls back to the site default). An empty '
+                'list from analysis is a bug; pass allow_clear=True only '
+                'when you intend to clear the post.'
+            )
         names = [self._resolve_id_to_name(cid) for cid in category_ids]
 
         old_names = []

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -611,6 +611,37 @@ class TestSetPostCategories(unittest.TestCase):
         self.assertIn('dropped=[2]', str(ctx.exception))
 
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_empty_list_raises_without_allow_clear(self, mock_urlopen):
+        """An empty cats list is a bug, not a pass-through (apply.md).
+
+        Sending `categories_by_id: []` wipes the post's categories and
+        WordPress reassigns it to the default. The adapter must refuse an
+        empty list unless the caller explicitly opts into clearing, and
+        must not issue any HTTP request when it refuses.
+        """
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(ValueError):
+            adapter.set_post_categories(100, [])
+        mock_urlopen.assert_not_called()
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_empty_list_allowed_with_allow_clear(self, mock_urlopen):
+        """allow_clear=True is the sanctioned way to intentionally clear
+        a post's categories (used by snapshot restore)."""
+        mock_urlopen.return_value = _mock_response({
+            'ID': 100,
+            'terms': {'category': {}},
+        })
+        adapter = WpcomAdapter(VALID_CONFIG)
+        # Must not raise.
+        adapter.set_post_categories(100, [], allow_clear=True)
+
+        req = mock_urlopen.call_args_list[0][0][0]
+        self.assertIn('/rest/v1.2/', req.full_url)
+        body = json.loads(req.data.decode('utf-8'))
+        self.assertEqual(body, {'categories_by_id': []})
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
     def test_accepts_legacy_categories_response_shape(self, mock_urlopen):
         """Fallback: some responses key category info under `categories`
         (name-keyed hash) instead of `terms.category` (slug-keyed)."""


### PR DESCRIPTION


WordPress.com treats `POST {categories_by_id: []}` as a wipe: it strips every category off the post, and WordPress then drops the post into the site's default category. `apply.md` already says an empty `cats` list from analysis is a bug, not something to pass through. But `WpcomAdapter.set_post_categories()` had no guard, so a single stray empty entry would silently clear a post's categories; and since the drift check was gated on `if sent_ids`, the empty case skipped it, so the wipe went undetected.

Now an empty `category_ids` raises a `ValueError` unless the caller passes the new `allow_clear=True` (reserved for intentional clears, like restore). I documented the behavior in `apply.md` and added regression tests for both the refusal and the explicit-clear path.

While testing against a live Jetpack site I confirmed the guard fires: an empty list is rejected before any request goes out, so a stray empty entry can't reach WordPress.com and trigger the wipe.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean

