### PR TITLE
Emit category_ids in the WordPress.com post export

### DIFF
--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -437,6 +437,7 @@ class WpcomAdapter:
                 # Normalize categories from {name: {ID: ...}} hash to list.
                 cat_hash = post.get('categories') or {}
                 cat_names = list(cat_hash.keys())
+                cat_ids = [int(v['ID']) for v in cat_hash.values()]
                 cat_slugs = [v.get('slug', '') for v in cat_hash.values()]
 
                 content = post.get('content', '')
@@ -450,6 +451,7 @@ class WpcomAdapter:
                     'date': post.get('date', ''),
                     'content': content,
                     'categories': cat_names,
+                    'category_ids': cat_ids,
                     'category_slugs': cat_slugs,
                     'url': post.get('URL', ''),
                 })

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -701,6 +701,44 @@ class TestExportPosts(unittest.TestCase):
             os.unlink(output_path)
 
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_export_includes_category_ids(self, mock_urlopen):
+        """category_ids is the canonical identifier and is required by
+        validate_export and the apply log contract. The wpcom export must
+        emit it, matching the WP-CLI export and backup()."""
+        import helpers
+        post = {
+            'ID': 1,
+            'title': 'Test',
+            'content': 'Body',
+            'date': '2024-01-01',
+            'categories': {
+                'Tech': {'ID': 10, 'slug': 'tech'},
+                'AI': {'ID': 20, 'slug': 'ai'},
+            },
+            'URL': 'https://example.com/test',
+        }
+        mock_urlopen.return_value = _mock_response({
+            'found': 1, 'posts': [post], 'meta': {},
+        })
+        adapter = WpcomAdapter(VALID_CONFIG)
+
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.export_posts(output_path)
+            with open(output_path) as f:
+                exported = json.load(f)
+            self.assertEqual(exported[0]['category_ids'], [10, 20])
+            self.assertTrue(all(
+                isinstance(cid, int) for cid in exported[0]['category_ids']
+            ))
+            # The export must satisfy the shared export-format validator.
+            check = helpers.validate_export(exported)
+            self.assertTrue(check['valid'], check['errors'])
+        finally:
+            os.unlink(output_path)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
     def test_pagination(self, mock_urlopen):
         post1 = {
             'ID': 1, 'title': 'P1', 'content': '', 'date': '',


### PR DESCRIPTION
The WordPress.com export was missing the `category_ids` field. `export_posts()` emitted category names and slugs but not the term IDs, even though the category hash it reads already carries them. That broke two things: `validate_export()` requires `category_ids` as a list of ints, so every WordPress.com export failed validation; and `apply.md` expects `old_category_ids` to come from the in-memory export so category changes can be logged reversibly. The WP-CLI export and `backup()` both already include term IDs, so this brings the WordPress.com path in line with them.

The fix adds `category_ids` (cast to int) to each exported post. I added a regression test that asserts the IDs are present, are integers, and that the export passes `validate_export`.

I also re-ran the full export against a live Jetpack site with ~9,000 posts; every post came back with its `category_ids`, and the export validated cleanly.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
