### PR TITLE
Clear posts with no backup categories during snapshot restore

### DIFF
--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -1605,8 +1605,13 @@ class WpcomAdapter:
                                 f'Category slug "{s}" missing during restore',
                             )
                         ids.append(int(live['ID']))
-                    if ids:
-                        self.set_post_categories(int(post_id), ids)
+                    # Posts that had no categories at backup time must be
+                    # cleared back to empty (allow_clear), otherwise a
+                    # category the apply run added is left in place and the
+                    # snapshot no longer matches the backup.
+                    self.set_post_categories(
+                        int(post_id), ids, allow_clear=True,
+                    )
                     if restore_log_path:
                         self._log_restore_op(
                             restore_log_path, op, status='ok',

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -1448,6 +1448,27 @@ class TestRestoreFromSnapshot(unittest.TestCase):
         self.assertTrue(result['dry_run'])
         self.assertEqual(set(adapter.cats.keys()), cats_before)
 
+    def test_restores_post_that_had_no_categories(self):
+        """A post with zero categories at backup time must be cleared
+        back to zero on restore, not silently left with whatever the
+        apply run added. Mirrors restore.php's unconditional empty set."""
+        posts = {
+            123: {'ID': 123, 'title': 'Hello', 'categories': {}},
+        }
+        adapter = FakeWpcom(cats=_make_cats(), posts=posts)
+        adapter.backup(self.backup)
+
+        # Simulate the apply run adding a category to the post.
+        adapter.set_post_categories(123, [2])
+        self.assertEqual(list(adapter.posts[123]['categories'].keys()), ['Tech'])
+
+        result = adapter.restore(
+            backup_path=self.backup, mode=MODE_SNAPSHOT, dry_run=False,
+        )
+        self.assertFalse(result['errors'])
+        # The added category must be gone — back to the empty backup state.
+        self.assertEqual(adapter.posts[123]['categories'], {})
+
 
 class TestRestoreAutoMode(unittest.TestCase):
     """Tests for mode=auto fallback behavior."""


### PR DESCRIPTION
`restore_from_snapshot` guarded its per-post reassignment with `if ids:`, so a post that had zero categories at backup time was skipped entirely. If the apply run had added a category to such a post, the snapshot restore left that category in place, which contradicts the promise that the taxonomy after a restore exactly matches the backup. The WP-CLI `restore.php` already calls `wp_set_post_categories($id, [])` unconditionally, so the two restore paths disagreed on this case.

Now the restore always calls `set_post_categories()`, passing `allow_clear=True` so an empty list genuinely clears the post (the empty-list guard otherwise rejects it). I added a regression test covering a post that had no categories at backup time: it picks up a category during a simulated apply, and the restore strips it back to empty.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
