### PR TITLE
Paginate WordPress.com post export by offset, not page_handle

### DIFF
--- a/agents/export.md
+++ b/agents/export.md
@@ -77,16 +77,22 @@ curl -H 'Authorization: Bearer TOKEN' \
   'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/categories?number=1000'
 ```
 
-Posts (max 100 per page, use `page_handle` for efficient pagination):
+Posts (max 100 per page, paginate by `offset`):
 ```bash
 # First page
 curl -H 'Authorization: Bearer TOKEN' \
-  'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/posts?number=100&status=publish&fields=ID,title,content,date,categories'
+  'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/posts?number=100&offset=0&status=publish&fields=ID,title,content,date,categories,URL'
 
-# Subsequent pages — use meta.next_page from previous response
+# Subsequent pages — increment offset by 100 until a page comes back empty
 curl -H 'Authorization: Bearer TOKEN' \
-  'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/posts?page_handle=HANDLE'
+  'https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/posts?number=100&offset=100&status=publish&fields=ID,title,content,date,categories,URL'
 ```
+
+The v1.1 posts endpoint does not return `meta.next_page`, so a
+`page_handle` loop silently truncates to the first 100 posts. Use
+`offset` pagination and dedupe post IDs across pages (offset can repeat a
+row at a page boundary if the underlying set shifts). `WpcomAdapter.export_posts()`
+implements exactly this.
 
 Note: Categories in post responses are a hash keyed by name (`{"Tech": {"ID": 123, ...}}`), not an array. Convert them to saved `categories`, `category_ids`, and `category_slugs` fields when exporting.
 

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -413,27 +413,40 @@ class WpcomAdapter:
         """
         Export all published posts with categories to a JSON file.
 
-        Uses page_handle cursor pagination. Normalizes category hashes
-        to lists.
+        Uses offset pagination with dedupe. The v1.1 posts endpoint does
+        not return `meta.next_page` (see backup()), so a page_handle loop
+        silently truncates to the first 100 posts; offset is the shape the
+        endpoint actually supports. Normalizes category hashes to lists.
 
         Args:
             output_path: Path to write the JSON file.
         """
         all_posts = []
-        page_handle = None
+        seen_ids = set()
+        offset = 0
 
         while True:
-            params = {
+            resp = self._get(f'/sites/{self.site_id}/posts', params={
                 'number': 100,
+                'offset': offset,
                 'status': 'publish',
-                'fields': 'ID,title,content,date,categories',
-            }
-            if page_handle:
-                params['page_handle'] = page_handle
-            resp = self._get(f'/sites/{self.site_id}/posts', params=params)
-            posts = resp.get('posts', [])
+                'fields': 'ID,title,content,date,categories,URL',
+            })
+            posts = resp.get('posts') or []
+            if not posts:
+                break
 
+            new_in_batch = 0
             for post in posts:
+                post_id = post['ID']
+                # Offset pagination can return duplicates at page
+                # boundaries if the underlying query shifts between
+                # calls. Dedupe so the export stays stable.
+                if post_id in seen_ids:
+                    continue
+                seen_ids.add(post_id)
+                new_in_batch += 1
+
                 # Normalize categories from {name: {ID: ...}} hash to list.
                 cat_hash = post.get('categories') or {}
                 cat_names = list(cat_hash.keys())
@@ -446,7 +459,7 @@ class WpcomAdapter:
                 content = re.sub(r'\s+', ' ', content).strip()
 
                 all_posts.append({
-                    'post_id': post['ID'],
+                    'post_id': post_id,
                     'title': post.get('title', ''),
                     'date': post.get('date', ''),
                     'content': content,
@@ -456,10 +469,9 @@ class WpcomAdapter:
                     'url': post.get('URL', ''),
                 })
 
-            meta = resp.get('meta', {})
-            page_handle = meta.get('next_page')
-            if not page_handle or not posts:
+            if new_in_batch == 0:
                 break
+            offset += 100
 
         with open(output_path, 'w', encoding='utf-8') as f:
             json.dump(all_posts, f, ensure_ascii=False)

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -738,24 +738,26 @@ class TestExportPosts(unittest.TestCase):
         finally:
             os.unlink(output_path)
 
+    def _post(self, pid):
+        return {
+            'ID': pid, 'title': f'P{pid}', 'content': '', 'date': '',
+            'categories': {}, 'URL': '',
+        }
+
     @patch('adapters.wpcom_adapter.urllib.request.urlopen')
-    def test_pagination(self, mock_urlopen):
-        post1 = {
-            'ID': 1, 'title': 'P1', 'content': '', 'date': '',
-            'categories': {}, 'URL': '',
-        }
-        post2 = {
-            'ID': 2, 'title': 'P2', 'content': '', 'date': '',
-            'categories': {}, 'URL': '',
-        }
+    def test_pagination_does_not_rely_on_next_page(self, mock_urlopen):
+        """Regression: the v1.1 posts endpoint does not return
+        meta.next_page (see backup() comment), so a page_handle loop
+        truncates to the first 100 posts. Export must paginate by offset
+        and keep going even when meta is empty."""
         mock_urlopen.side_effect = [
-            _mock_response({
-                'found': 2, 'posts': [post1],
-                'meta': {'next_page': 'cursor123'},
-            }),
-            _mock_response({
-                'found': 2, 'posts': [post2], 'meta': {},
-            }),
+            # Two full pages, neither carrying meta.next_page.
+            _mock_response({'found': 4, 'posts': [self._post(1), self._post(2)],
+                            'meta': {}}),
+            _mock_response({'found': 4, 'posts': [self._post(3), self._post(4)],
+                            'meta': {}}),
+            # Empty page terminates the loop.
+            _mock_response({'found': 4, 'posts': [], 'meta': {}}),
         ]
         adapter = WpcomAdapter(VALID_CONFIG)
 
@@ -765,7 +767,37 @@ class TestExportPosts(unittest.TestCase):
             adapter.export_posts(output_path)
             with open(output_path) as f:
                 exported = json.load(f)
-            self.assertEqual(len(exported), 2)
+            self.assertEqual([p['post_id'] for p in exported], [1, 2, 3, 4])
+            # Pagination must walk offsets and must never send page_handle.
+            offsets = [
+                c[0][0].full_url for c in mock_urlopen.call_args_list
+            ]
+            self.assertTrue(any('offset=100' in u for u in offsets))
+            self.assertFalse(any('page_handle' in u for u in offsets))
+        finally:
+            os.unlink(output_path)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_pagination_dedupes_boundary_duplicates(self, mock_urlopen):
+        """Offset pagination can return a row twice at a page boundary if
+        the underlying set shifts. Export must dedupe, like backup()."""
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 3, 'posts': [self._post(1), self._post(2)],
+                            'meta': {}}),
+            # post2 repeats at the boundary; post3 is new.
+            _mock_response({'found': 3, 'posts': [self._post(2), self._post(3)],
+                            'meta': {}}),
+            _mock_response({'found': 3, 'posts': [], 'meta': {}}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.export_posts(output_path)
+            with open(output_path) as f:
+                exported = json.load(f)
+            self.assertEqual([p['post_id'] for p in exported], [1, 2, 3])
         finally:
             os.unlink(output_path)
 


### PR DESCRIPTION
`export_posts()` walked pages using `meta.next_page` / `page_handle`, but `backup()` already documents (verified empirically) that the v1.1 posts endpoint doesn't return `meta.next_page`. With an empty `meta`, the `page_handle` loop breaks after the first page, so the export silently truncated to the first 100 posts; analysis then only ever saw a fraction of the site's content.

This switches `export_posts()` to the same offset pagination plus ID dedupe that `backup()` uses, so the two methods agree on how to walk the endpoint. I also added `URL` to the requested fields: the code read `post['URL']` but never asked for it, so the exported `url` was always empty in production.

I confirmed it against a live Jetpack site with ~9,000 posts: the export now returns all 9,073 (not 100), every post is unique (the dedupe holds across ~90 page boundaries), and the `category_ids` come through. I added regression tests proving pagination no longer relies on `next_page` and that boundary duplicates are deduped, and updated `export.md`.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
