### PR TITLE
Stop guessing category ID 1 as the site default

### DIFF
--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -840,7 +840,15 @@ class WpcomAdapter:
         """
         resp = self._get(f'/sites/{self.site_id}/settings')
         settings = resp if 'default_category' in resp else resp.get('settings', {})
-        default_id = settings.get('default_category', 1)
+        # Don't guess a fallback ID: a wrong default feeds the restore
+        # delete-protection logic and could let the real default be deleted.
+        if 'default_category' not in settings:
+            raise WpcomApiError(
+                500, 'default_category_unknown',
+                'Settings response did not include default_category; '
+                'refusing to guess the site default category.',
+            )
+        default_id = settings['default_category']
 
         cat = self._get_category_by_id(default_id)
         if cat is None:
@@ -949,12 +957,16 @@ class WpcomAdapter:
         # Resolve default category slug. The /sites/{id}/settings endpoint
         # requires authentication even on public sites, so suppress 401/403
         # to allow read-only backups without a token. Also suppress 404
-        # (category genuinely missing). Other errors should propagate.
+        # (category genuinely missing) and default_category_unknown (the
+        # settings response didn't carry a default) — in both cases the
+        # backup records an empty default and continues rather than failing
+        # outright. Other errors should propagate.
         try:
             default_cat = self.get_default_category()
             default_slug = default_cat.get('slug', '')
         except WpcomApiError as e:
-            if e.status_code in (401, 403, 404):
+            if (e.status_code in (401, 403, 404)
+                    or e.error == 'default_category_unknown'):
                 default_slug = ''
             else:
                 raise

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -862,6 +862,22 @@ class TestGetDefaultCategory(unittest.TestCase):
         result = adapter.get_default_category()
         self.assertEqual(result['name'], 'Uncategorized')
 
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_raises_when_settings_missing_default(self, mock_urlopen):
+        """If the settings response carries no default_category, raise
+        rather than silently assuming category ID 1. A wrong default feeds
+        the restore delete-protection logic and could let the real default
+        be deleted."""
+        cat = {'ID': 1, 'name': 'Uncategorized', 'slug': 'uncategorized',
+               'parent': 0}
+        mock_urlopen.side_effect = [
+            _mock_response({'settings': {}}),  # no default_category
+            _mock_response({'found': 1, 'categories': [cat]}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with self.assertRaises(WpcomApiError):
+            adapter.get_default_category()
+
 
 class TestBackup(unittest.TestCase):
     """Tests for full taxonomy backup.
@@ -958,6 +974,36 @@ class TestBackup(unittest.TestCase):
             self.assertEqual(backup['total_posts'], 250)
             ids = [p['post_id'] for p in backup['post_categories']]
             self.assertEqual(ids, list(range(1, 251)))
+        finally:
+            os.unlink(output_path)
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_backup_degrades_when_default_unknown(self, mock_urlopen):
+        """If /settings returns 200 but without default_category, the
+        backup must still succeed with an empty default_category_slug
+        rather than propagating the (now loud) unknown-default error."""
+        cat = {'ID': 1, 'name': 'Tech', 'slug': 'tech', 'parent': 0,
+               'description': 'Technology', 'post_count': 5}
+        post = {
+            'ID': 100, 'title': 'Test',
+            'categories': {'Tech': {'ID': 1, 'slug': 'tech'}},
+        }
+        mock_urlopen.side_effect = [
+            _mock_response({'found': 1, 'categories': [cat]}),
+            _mock_response({'found': 1, 'posts': [post], 'meta': {}}),
+            _mock_response({'found': 1, 'posts': [], 'meta': {}}),
+            # settings present but missing default_category
+            _mock_response({'settings': {}}),
+        ]
+        adapter = WpcomAdapter(VALID_CONFIG)
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            output_path = f.name
+        try:
+            adapter.backup(output_path)
+            with open(output_path) as f:
+                backup = json.load(f)
+            self.assertEqual(backup['default_category_slug'], '')
+            self.assertEqual(backup['total_posts'], 1)
         finally:
             os.unlink(output_path)
 


### PR DESCRIPTION
`get_default_category()` fell back to category ID 1 when the settings response didn't include a `default_category`. If the real default was a different category and ID 1 happened to exist, it silently returned the wrong default. That feeds the restore delete-protection logic, so a wrong guess could let the real default category be deleted.

Now it raises `WpcomApiError('default_category_unknown')` instead of guessing. `backup()` suppresses that new error alongside the existing 401/403/404 cases, so a token-less or unusual-settings backup still records an empty default and keeps going rather than failing outright. I added regression tests for both the raise and the backup degradation.

On a live Jetpack site, `get_default_category()` returned the real default (Uncategorized) correctly.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
