### PR TITLE
Check wp_update_term return in restore.php hierarchy step

### DIFF
--- a/lib/restore.php
+++ b/lib/restore.php
@@ -163,7 +163,7 @@ foreach ( $backup['categories'] as $category ) {
 		$current_term->slug !== $category['slug']
 	);
 	if ( $needs_fix ) {
-		wp_update_term(
+		$update_result = wp_update_term(
 			$current_id,
 			'category',
 			array(
@@ -172,7 +172,14 @@ foreach ( $backup['categories'] as $category ) {
 				'slug'   => $category['slug'],
 			)
 		);
-		++$hierarchy_fixed;
+		// A slug/name restore can hit its own collision (another live term
+		// already holds the target slug). Surface it instead of silently
+		// leaving the category stuck with the temporary '-taxonomist-…' slug.
+		if ( is_wp_error( $update_result ) ) {
+			WP_CLI::warning( "Failed to restore name/slug/parent for category '$slug': " . $update_result->get_error_message() );
+		} else {
+			++$hierarchy_fixed;
+		}
 	}
 }
 


### PR DESCRIPTION
Step 2 of `restore.php` restores each category's real name/slug/parent after Step 1 may have inserted it under a temporary `-taxonomist-<uniqid>` slug to dodge a root-level collision. The `wp_update_term` return was ignored, so if the slug rename hit its own collision (another live term already holds the target slug), the category was left stuck with the temporary slug and the `WP_Error` was swallowed.

Now it captures the return, warns via `WP_CLI` on a `WP_Error`, and only counts the fix as applied on success.

There's no unit test here: `restore.php` runs under `wp eval-file` and needs a live WordPress environment, which the repo's test setup (phpcs + Python unittest) doesn't provide. I did exercise it against a live site though: deleted a parent category, ran the full restore, and confirmed the category was recreated and its child re-attached to it by slug, with the hierarchy step reporting the fix.

### Testing
- `./vendor/bin/phpcs` — clean
- `python3 -m unittest discover tests` — green (unaffected)
