### PR TITLE
Let inverse-replay revert posts back to zero categories

### DIFF
--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -534,7 +534,10 @@ class WpcomAdapter:
         names = [self._resolve_id_to_name(cid) for cid in category_ids]
 
         old_names = []
-        if self.changes_log_path and not old_category_ids:
+        # Distinguish "not provided" (None → unrevertable log row) from
+        # "provided, but the post had no categories" ([] → a valid empty
+        # old state). Only None is an error.
+        if self.changes_log_path and old_category_ids is None:
             raise ValueError(
                 f'set_post_categories(post_id={post_id}): '
                 'old_category_ids is required when logging is enabled. '
@@ -1303,7 +1306,10 @@ class WpcomAdapter:
                         f'"{name}" no longer exists',
                     )
                 ids.append(cat['ID'])
-            self.set_post_categories(post_id, ids)
+            # An empty old state means the post had no categories before the
+            # apply run; allow_clear lets us restore it to that empty state
+            # instead of tripping the empty-list guard.
+            self.set_post_categories(post_id, ids, allow_clear=True)
             return op
 
         if source == SOURCE_TERM and action == ACTION_CREATE_CAT:

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -1324,6 +1324,22 @@ class TestLogging(unittest.TestCase):
             adapter.set_post_categories(123, [2])
         self.assertIn('old_category_ids is required', str(ctx.exception))
 
+    def test_set_post_categories_accepts_empty_old_ids(self):
+        """A post that had zero categories before apply must be loggable:
+        old_category_ids=[] means 'had none', which is different from None
+        ('caller forgot to pass it')."""
+        adapter = FakeWpcom(cats=_make_cats(),
+                            posts={123: {'ID': 123, 'title': 'Hello',
+                                         'categories': {}}})
+        adapter.set_logging(changes_log_path=self.changes)
+        # Must not raise.
+        adapter.set_post_categories(
+            123, [2], old_category_ids=[], post_title='Hello',
+        )
+        from helpers import parse_change_log
+        rows = parse_change_log(self.changes)
+        self.assertEqual(rows[0]['old_categories'], '')
+
     def test_set_default_logs(self):
         adapter = FakeWpcom(cats=_make_cats())
         adapter.set_logging(terms_log_path=self.terms)
@@ -1371,6 +1387,35 @@ class TestRestoreFromLogs(unittest.TestCase):
             dry_run=False,
         )
         return adapter, result
+
+    def test_reverts_post_that_had_no_categories(self):
+        """Inverse-replay must clear a post back to zero categories when
+        its logged old state was empty, instead of raising ValueError
+        (which the empty-list guard would otherwise trigger)."""
+        adapter = FakeWpcom(
+            cats=_make_cats(),
+            posts={123: {'ID': 123, 'title': 'Hello', 'categories': {}}},
+        )
+        adapter.backup(self.backup)
+        adapter.set_logging(self.changes, self.terms)
+        # Apply adds a category to a previously-uncategorized post.
+        adapter.set_post_categories(
+            123, [2], old_category_ids=[], post_title='Hello',
+        )
+        self.assertEqual(
+            list(adapter.posts[123]['categories'].keys()), ['Tech'],
+        )
+
+        adapter.set_logging()
+        result = adapter.restore(
+            backup_path=self.backup,
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS, dry_run=False,
+        )
+        self.assertFalse(result['errors'])
+        # The added category must be gone — back to the empty pre-apply state.
+        self.assertEqual(adapter.posts[123]['categories'], {})
 
     def test_round_trip(self):
         """Apply + revert should recover the baseline exactly."""


### PR DESCRIPTION
Two coupled defects blocked reverting a post that had no categories before an apply run.

First, `set_post_categories` rejected `old_category_ids=[]` with the same error as omitting it (`not old_category_ids` is true for both `None` and `[]`), so a previously-uncategorized post couldn't be applied-with-logging at all.

Second, the `SET_CATS` inverse called `set_post_categories(post_id, [])` without `allow_clear`, which the empty-list guard rejects; that turned the revert into a `PartialRestoreError` and left the apply-added category in place.

The fix distinguishes `None` (missing, unrevertable) from `[]` (the post genuinely had no categories) in the guard, and passes `allow_clear=True` in the inverse so an empty old state clears the post. This mirrors the snapshot-restore path. I added round-trip regression tests for both the apply and revert sides.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
