### PR TITLE
Validate category references by term ID, not slug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,18 +204,23 @@ if not check['valid']:
 
 This catches a known failure mode where an analyze agent outputs array indices (0, 1, 2, …) instead of real WordPress post IDs. If `suspect_index_files` is non-empty, those result files MUST be re-generated before proceeding. Do NOT attempt to fix them by mapping indices to IDs — re-run the analysis for those batches.
 
-### 2. Category slug validation
+### 2. Category term ID validation
+
+Suggestions carry integer `term_id`s in their `cats` list (see
+`agents/analyze.md`), so validate them against the set of valid term IDs —
+not slugs.
 
 ```python
-from helpers import validate_category_slugs
-valid_slugs = {cat['slug'] for cat in categories}
-check = validate_category_slugs(all_suggestions, valid_slugs)
+from helpers import validate_category_ids
+valid_ids = {cat['term_id'] for cat in categories}
+check = validate_category_ids(all_suggestions, valid_ids)
 if not check['valid']:
     for error in check['errors']:
         print(error)
 ```
 
-Any unknown slugs must be resolved (typo, or a new category the user hasn't approved yet) before applying.
+Any unknown term IDs must be resolved (a stale ID from a re-exported
+taxonomy, or a new category the user hasn't approved yet) before applying.
 
 ### 3. Category distribution review
 

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -614,36 +614,44 @@ def validate_result_ids(results_dir, batch_dir):
     }
 
 
-def validate_category_slugs(suggestions, valid_slugs):
+def validate_category_ids(suggestions, valid_ids):
     """
-    Check that every category slug in the suggestions exists in the valid set.
+    Check that every category term ID in the suggestions is recognized.
+
+    Analysis output puts integer term IDs in each suggestion's `cats`
+    list (see agents/analyze.md — "always output the term_id in cats"),
+    and validate_suggestions enforces that they are ints. This gate
+    therefore validates those IDs against the set of valid term IDs, not
+    against slug strings, so a stale or typo'd category reference is
+    caught before it reaches apply.
 
     Args:
-        suggestions: List of suggestion dicts (each with a 'cats' list).
-        valid_slugs: Set of valid category slug strings.
+        suggestions: List of suggestion dicts (each with a 'cats' list of
+            integer term IDs).
+        valid_ids: Set of valid category term IDs (ints).
 
     Returns:
         A dict with keys:
-            valid (bool): True if all slugs are recognized.
-            unknown_slugs (Counter): slug -> count of occurrences.
+            valid (bool): True if all IDs are recognized.
+            unknown_ids (Counter): term ID -> count of occurrences.
             errors (list[str]): Human-readable error descriptions.
     """
     unknown = Counter()
     for entry in suggestions:
         for cat in entry.get('cats', []):
-            if cat not in valid_slugs:
+            if cat not in valid_ids:
                 unknown[cat] += 1
 
     errors = []
     if unknown:
         errors.append(
-            f'{len(unknown)} unknown category slug(s): '
-            + ', '.join(f'{slug} ({n}x)' for slug, n in unknown.most_common(10))
+            f'{len(unknown)} unknown category term ID(s): '
+            + ', '.join(f'{cid} ({n}x)' for cid, n in unknown.most_common(10))
         )
 
     return {
         'valid': len(errors) == 0,
-        'unknown_slugs': unknown,
+        'unknown_ids': unknown,
         'errors': errors,
     }
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -29,7 +29,7 @@ from helpers import (
     resolve_category_export_row,
     split_into_batches,
     validate_backup,
-    validate_category_slugs,
+    validate_category_ids,
     validate_export,
     validate_result_ids,
     validate_suggestions,
@@ -1178,35 +1178,52 @@ class TestValidateResultIds(unittest.TestCase):
             self.assertEqual(len(check['missing_ids']), 0)
 
 
-class TestValidateCategorySlugs(unittest.TestCase):
-    """Tests for category slug validation in suggestions."""
+class TestValidateCategoryIds(unittest.TestCase):
+    """Tests for category term ID validation in suggestions.
+
+    Suggestion `cats` lists contain integer term IDs (see analyze.md), so
+    validation must compare against the set of valid term IDs, not slugs.
+    """
 
     def test_all_valid(self):
         suggestions = [
-            {'post_id': 1, 'cats': ['tech', 'food']},
-            {'post_id': 2, 'cats': ['art']},
+            {'post_id': 1, 'cats': [12, 34]},
+            {'post_id': 2, 'cats': [56]},
         ]
-        check = validate_category_slugs(suggestions, {'tech', 'food', 'art'})
+        check = validate_category_ids(suggestions, {12, 34, 56})
         self.assertTrue(check['valid'])
-        self.assertEqual(len(check['unknown_slugs']), 0)
+        self.assertEqual(len(check['unknown_ids']), 0)
 
-    def test_detects_unknown_slugs(self):
+    def test_detects_unknown_ids(self):
         suggestions = [
-            {'post_id': 1, 'cats': ['tech', 'bogus']},
-            {'post_id': 2, 'cats': ['bogus', 'also-fake']},
+            {'post_id': 1, 'cats': [12, 999]},
+            {'post_id': 2, 'cats': [999, 888]},
         ]
-        check = validate_category_slugs(suggestions, {'tech', 'food'})
+        check = validate_category_ids(suggestions, {12, 34})
         self.assertFalse(check['valid'])
-        self.assertEqual(check['unknown_slugs']['bogus'], 2)
-        self.assertEqual(check['unknown_slugs']['also-fake'], 1)
+        self.assertEqual(check['unknown_ids'][999], 2)
+        self.assertEqual(check['unknown_ids'][888], 1)
+
+    def test_real_pipeline_shape_passes(self):
+        """Regression: integer cats validated against a set of integer term
+        IDs must pass. The old slug-based check flagged every real ID as
+        unknown because it compared ints to slug strings."""
+        categories = [
+            {'term_id': 12, 'slug': 'tech'},
+            {'term_id': 34, 'slug': 'food'},
+        ]
+        valid_ids = {cat['term_id'] for cat in categories}
+        suggestions = [{'post_id': 1, 'cats': [12, 34]}]
+        check = validate_category_ids(suggestions, valid_ids)
+        self.assertTrue(check['valid'], check['errors'])
 
     def test_empty_suggestions(self):
-        check = validate_category_slugs([], {'tech'})
+        check = validate_category_ids([], {12})
         self.assertTrue(check['valid'])
 
     def test_empty_cats(self):
         suggestions = [{'post_id': 1, 'cats': []}]
-        check = validate_category_slugs(suggestions, {'tech'})
+        check = validate_category_ids(suggestions, {12})
         self.assertTrue(check['valid'])
 
 


### PR DESCRIPTION
The documented pre-apply gate compared each suggestion's `cats` entries against a set of slug strings, but `analyze.md` and `validate_suggestions` define `cats` as integer term IDs. Against real pipeline data the check flagged every valid ID as an unknown slug; the only reason the tests passed was that they fed slug strings into `cats`, a shape no real result file has. So the gate AGENTS.md calls mandatory ("any unknown references must be resolved before applying") never actually guarded the real data.

This renames `validate_category_slugs` to `validate_category_ids` and validates `cats` against the set of valid term IDs. I updated AGENTS.md to build `valid_ids` from `term_id`, and rewrote the tests to use the real integer-`cats` shape.

I also ran it against a live export of ~9,000 posts: every real category reference validated, and a planted bogus ID was correctly flagged.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
