### PR TITLE
Harden WP-CLI adapter against argument injection

### DIFF
--- a/lib/adapters/wp_cli_adapter.py
+++ b/lib/adapters/wp_cli_adapter.py
@@ -6,6 +6,25 @@ import subprocess
 import tempfile
 
 
+def _reject_option_like(value, label):
+    """Refuse a value that could be parsed as a command-line option.
+
+    A config or content value beginning with '-' can be interpreted by
+    ssh, scp, or wp as an option rather than data. For example a
+    ssh_user of '-oProxyCommand=touch /tmp/x' makes ssh run a local
+    command before connecting, and a category name of '--require=evil.php'
+    makes wp load arbitrary PHP. Fail closed rather than risk argument
+    injection. '--' separators are added at the call sites as well, but
+    OpenSSH still parses '-'-leading hostnames after '--', so this
+    validation is the load-bearing guard.
+    """
+    if isinstance(value, str) and value.startswith('-'):
+        raise ValueError(
+            f'{label} may not start with "-" (it would be parsed as a '
+            f'command-line option): {value!r}'
+        )
+
+
 class WpCliAdapter:
     """
     Adapter for interacting with WordPress via WP-CLI.
@@ -31,12 +50,15 @@ class WpCliAdapter:
         ssh_host = self.connection.get('ssh_host')
         if not ssh_user or not ssh_host:
             raise ValueError('wp-cli-ssh requires ssh_user and ssh_host')
+        _reject_option_like(ssh_user, 'ssh_user')
+        _reject_option_like(ssh_host, 'ssh_host')
         return f'{ssh_user}@{ssh_host}'
 
     def _run_remote_shell(self, command):
         """Run a safely quoted command string on the remote host over SSH."""
+        target = self._ssh_target()
         result = subprocess.run(
-            ['ssh', self._ssh_target(), command],
+            ['ssh', '--', target, command],
             capture_output=True,
             text=True,
         )
@@ -87,7 +109,8 @@ class WpCliAdapter:
                     env={'TAXONOMIST_OUTPUT': remote_output},
                 )
                 result = subprocess.run(
-                    ['scp', f'{self._ssh_target()}:{remote_output}', output_path],
+                    ['scp', '--',
+                     f'{self._ssh_target()}:{remote_output}', output_path],
                     capture_output=True,
                     text=True,
                 )
@@ -113,6 +136,12 @@ class WpCliAdapter:
 
     def create_category(self, name, slug, description=''):
         """Create a new category."""
+        # name is a bare positional; a '-'-leading value would be parsed
+        # by wp as a global flag (e.g. --require=). slug/description are
+        # bound to their --flag= token, but reject '-'-leading values too
+        # as defense in depth.
+        _reject_option_like(name, 'category name')
+        _reject_option_like(slug, 'category slug')
         args = ['term', 'create', 'category', name, f'--slug={slug}']
         if description:
             args.append(f'--description={description}')

--- a/tests/test_wp_cli_adapter.py
+++ b/tests/test_wp_cli_adapter.py
@@ -1,0 +1,102 @@
+"""
+Tests for the WP-CLI adapter.
+
+Focused on argument-injection hardening: config values and content that
+begin with '-' must not be interpretable as ssh/wp command-line options.
+subprocess.run is patched so no real commands execute.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
+from adapters.wp_cli_adapter import WpCliAdapter
+
+
+def _local_config(**overrides):
+    conn = {'method': 'wp-cli-local', 'wp_path': '/var/www'}
+    conn.update(overrides)
+    return {'connection': conn}
+
+
+def _ssh_config(**overrides):
+    conn = {
+        'method': 'wp-cli-ssh',
+        'wp_path': '/var/www',
+        'ssh_user': 'root',
+        'ssh_host': 'example.com',
+    }
+    conn.update(overrides)
+    return {'connection': conn}
+
+
+def _ok_run():
+    """A subprocess.run mock returning a successful empty result."""
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = '[]'
+    result.stderr = ''
+    return result
+
+
+class TestSshTargetInjection(unittest.TestCase):
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_rejects_option_like_ssh_user(self, mock_run):
+        """A ssh_user beginning with '-' would be parsed by ssh as an
+        option (e.g. -oProxyCommand=...), enabling local code execution."""
+        adapter = WpCliAdapter(_ssh_config(ssh_user='-oProxyCommand=touch /tmp/x'))
+        with self.assertRaises(ValueError):
+            adapter.list_categories()
+        mock_run.assert_not_called()
+
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_rejects_option_like_ssh_host(self, mock_run):
+        adapter = WpCliAdapter(_ssh_config(ssh_host='-oProxyCommand=touch /tmp/x'))
+        with self.assertRaises(ValueError):
+            adapter.list_categories()
+        mock_run.assert_not_called()
+
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_ssh_invocation_uses_double_dash(self, mock_run):
+        mock_run.return_value = _ok_run()
+        adapter = WpCliAdapter(_ssh_config())
+        adapter.list_categories()
+        argv = mock_run.call_args[0][0]
+        self.assertEqual(argv[0], 'ssh')
+        # '--' must appear before the target so a future target value can't
+        # be parsed as an option.
+        self.assertIn('--', argv)
+        self.assertLess(argv.index('--'), argv.index('root@example.com'))
+
+
+class TestCreateCategoryInjection(unittest.TestCase):
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_rejects_option_like_name(self, mock_run):
+        """A category name beginning with '-' (e.g. --require=evil.php)
+        would be parsed by wp as a global flag → arbitrary PHP execution."""
+        adapter = WpCliAdapter(_local_config())
+        with self.assertRaises(ValueError):
+            adapter.create_category('--require=/tmp/evil.php', 'evil')
+        mock_run.assert_not_called()
+
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_rejects_option_like_slug(self, mock_run):
+        adapter = WpCliAdapter(_local_config())
+        with self.assertRaises(ValueError):
+            adapter.create_category('Tech', '--path=/etc')
+        mock_run.assert_not_called()
+
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_accepts_normal_name(self, mock_run):
+        mock_run.return_value = _ok_run()
+        adapter = WpCliAdapter(_local_config())
+        adapter.create_category('Tech', 'tech', 'Technology')
+        argv = mock_run.call_args[0][0]
+        self.assertIn('Tech', argv)
+        self.assertIn('--slug=tech', argv)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Two argument-injection vectors in the WP-CLI adapter.

`ssh_user` / `ssh_host` were interpolated into the ssh/scp target with no validation. A config value like `ssh_user='-oProxyCommand=touch /tmp/x'` is parsed by ssh as an option and runs an arbitrary command locally before connecting; that's local code execution from a tampered config or a prompt-injected connect step.

The category name passed to `wp term create` is a bare positional. A name like `--require=/tmp/evil.php` is parsed by wp as a global flag and loads arbitrary PHP into the WP-CLI process.

The fix rejects `ssh_user`, `ssh_host`, category name, and category slug values that begin with `-` (fail closed), and adds `--` separators to the ssh and scp invocations. The validation is the load-bearing part because OpenSSH still parses `-`-leading hostnames even after `--`. I added a test module covering both vectors (there were no WP-CLI adapter tests before).

While testing against a live site I confirmed the guards fire: `create_category('--require=…')` and a `--path=` slug both raise before any ssh call goes out.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
