### PR TITLE
Compare category IDs as ints in _get_category_by_id

### DIFF
--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -264,7 +264,17 @@ class WpcomAdapter:
         return None
 
     def _get_category_by_id(self, term_id):
-        return self._find_category(lambda c: c.get('ID') == term_id)
+        # WP.com sometimes returns IDs as strings; compare as ints so an
+        # int term_id still matches a string '49' (and vice versa).
+        def matches(c):
+            cid = c.get('ID')
+            if cid is None:
+                return False
+            try:
+                return int(cid) == int(term_id)
+            except (TypeError, ValueError):
+                return False
+        return self._find_category(matches)
 
     def _lookup_category_by_slug(self, slug):
         if not slug:

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -879,6 +879,23 @@ class TestGetDefaultCategory(unittest.TestCase):
             adapter.get_default_category()
 
 
+class TestGetCategoryById(unittest.TestCase):
+    """Tests for category lookup by term ID."""
+
+    @patch('adapters.wpcom_adapter.urllib.request.urlopen')
+    def test_matches_string_id_from_api(self, mock_urlopen):
+        """WP.com may return category IDs as strings; an int term_id must
+        still match a string '49' rather than spuriously 404ing mid-apply."""
+        cat = {'ID': '49', 'name': 'Tech', 'slug': 'tech', 'parent': 0}
+        mock_urlopen.return_value = _mock_response({
+            'found': 1, 'categories': [cat],
+        })
+        adapter = WpcomAdapter(VALID_CONFIG)
+        result = adapter._get_category_by_id(49)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['slug'], 'tech')
+
+
 class TestBackup(unittest.TestCase):
     """Tests for full taxonomy backup.
 


### PR DESCRIPTION
`_get_category_by_id` matched with `c.get('ID') == term_id`. The WP.com API sometimes returns term IDs as strings (the tree builder already coerces for this reason), so a string `'49'` in the cache wouldn't equal an int `49` and the lookup returned `None`, a spurious 404 that aborts an apply or restore mid-run.

This coerces both sides to `int` before comparing. I added a regression test with a string-typed ID from the API.

While testing against a live Jetpack site, passing a string term ID to `set_post_categories` resolved correctly.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
