### PR TITLE
Resolve change-log revert by category slug, not display name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,9 +159,9 @@ Every operation that modifies the site is logged to `data/logs/`. Each apply run
 - `data/backups/backup-{timestamp}.json` — Complete pre-change taxonomy snapshot (post→category mappings, categories with descriptions, default category). Always written before any mutation.
 - `data/logs/changes-{timestamp}.tsv` — Per-post category assignment changes. Schema:
   ```
-  timestamp  action  post_id  post_title  old_categories  new_categories  cats_added  cats_removed
+  timestamp  action  post_id  post_title  old_categories  new_categories  cats_added  cats_removed  old_category_slugs  new_category_slugs
   ```
-  Action is `SET_CATS`. Written by `lib/apply-changes.php` (WP-CLI) and by `WpcomAdapter.set_post_categories()` when logging is enabled.
+  Action is `SET_CATS`. Written by `lib/apply-changes.php` (WP-CLI) and by `WpcomAdapter.set_post_categories()` when logging is enabled. The `*_categories` columns hold display names for human readability; the `*_category_slugs` columns hold slugs and are the canonical key inverse-replay revert resolves against (slugs are unique per taxonomy and survive a delete+recreate, whereas display names can be ambiguous and term IDs change on recreation). Logs without the slug columns fall back to name-based resolution.
 - `data/logs/terms-{timestamp}.tsv` — Term-level operations (create / delete / update / set-default). Schema:
   ```
   timestamp  action  term_id  slug  field  old_value  new_value

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -544,6 +544,8 @@ class WpcomAdapter:
         names = [self._resolve_id_to_name(cid) for cid in category_ids]
 
         old_names = []
+        old_slugs = []
+        new_slugs = []
         # Distinguish "not provided" (None → unrevertable log row) from
         # "provided, but the post had no categories" ([] → a valid empty
         # old state). Only None is an error.
@@ -554,12 +556,17 @@ class WpcomAdapter:
                 'Pass the pre-change category IDs from the export so '
                 'the change log can record a reversible operation.'
             )
-        if self.changes_log_path and old_category_ids:
-            old_names = [
-                cat['name']
-                for cid in old_category_ids
-                for cat in (self._get_category_by_id(cid),)
-                if cat is not None
+        if self.changes_log_path:
+            for cid in old_category_ids or []:
+                cat = self._get_category_by_id(cid)
+                if cat is not None:
+                    old_names.append(cat['name'])
+                    old_slugs.append(cat.get('slug', ''))
+            # category_ids were already validated by _resolve_id_to_name
+            # above, so every lookup here resolves.
+            new_slugs = [
+                self._get_category_by_id(cid).get('slug', '')
+                for cid in category_ids
             ]
 
         # v1.2 + categories_by_id is the only sanctioned shape for
@@ -613,6 +620,8 @@ class WpcomAdapter:
                 new_categories=names,
                 cats_added=[n for n in names if n not in old_names],
                 cats_removed=[n for n in old_names if n not in names],
+                old_category_slugs=old_slugs,
+                new_category_slugs=new_slugs,
             )
 
     def _resolve_id_to_name(self, term_id):
@@ -1014,6 +1023,7 @@ class WpcomAdapter:
     POST_LOG_HEADER = (
         'timestamp', 'action', 'post_id', 'post_title',
         'old_categories', 'new_categories', 'cats_added', 'cats_removed',
+        'old_category_slugs', 'new_category_slugs',
     )
     TERM_LOG_HEADER = (
         'timestamp', 'action', 'term_id', 'slug',
@@ -1099,7 +1109,8 @@ class WpcomAdapter:
 
     def _log_post_change(self, action, post_id, post_title,
                          old_categories, new_categories,
-                         cats_added, cats_removed):
+                         cats_added, cats_removed,
+                         old_category_slugs=(), new_category_slugs=()):
         if not self.changes_log_path:
             return
         ts = self._log_timestamp()
@@ -1112,6 +1123,10 @@ class WpcomAdapter:
                 '|'.join(new_categories),
                 '|'.join(cats_added),
                 '|'.join(cats_removed),
+                # Slugs are the canonical revert key: unique per taxonomy,
+                # stable across a delete+recreate, and free of '|'.
+                '|'.join(old_category_slugs),
+                '|'.join(new_category_slugs),
             ),
         )
 
@@ -1295,25 +1310,40 @@ class WpcomAdapter:
 
         if source == SOURCE_CHANGE and action == ACTION_SET_CATS:
             post_id = int(row.get('post_id') or 0)
-            old_cat_names = [
-                n for n in (row.get('old_categories') or '').split('|') if n
-            ]
+            # Prefer slugs: unique per taxonomy (so duplicate display names
+            # can't map to the wrong category) and stable across a
+            # delete+recreate (the recreated term keeps its slug but gets a
+            # new ID). Fall back to names for logs written before slug
+            # columns existed or by the WP-CLI apply script.
+            old_slugs_raw = row.get('old_category_slugs')
+            by_slug = old_slugs_raw is not None
+            if by_slug:
+                keys = [s for s in old_slugs_raw.split('|') if s]
+            else:
+                keys = [
+                    n for n in (row.get('old_categories') or '').split('|')
+                    if n
+                ]
             op = {
                 'kind': 'set_post_categories',
                 'post_id': post_id,
-                'restore_to': old_cat_names,
+                'restore_to': keys,
                 'post_title': row.get('post_title', ''),
             }
             if dry_run:
                 return op
             ids = []
-            for name in old_cat_names:
-                cat = self._lookup_category_by_name(name)
+            for key in keys:
+                cat = (
+                    self._lookup_category_by_slug(key) if by_slug
+                    else self._lookup_category_by_name(key)
+                )
                 if cat is None:
+                    key_kind = 'slug' if by_slug else 'name'
                     raise WpcomApiError(
                         404, 'not_found',
                         f'Cannot restore post {post_id}: category '
-                        f'"{name}" no longer exists',
+                        f'{key_kind} "{key}" no longer exists',
                     )
                 ids.append(cat['ID'])
             # An empty old state means the post had no categories before the

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -737,7 +737,9 @@ def parse_change_log(log_path):
     same way they were written by PHP's fputcsv().
 
     Returns dicts with keys: timestamp, action, post_id, post_title,
-    old_categories, new_categories, cats_added, cats_removed.
+    old_categories, new_categories, cats_added, cats_removed, and (for logs
+    written by the wpcom adapter) old_category_slugs, new_category_slugs.
+    Older logs without the slug columns simply omit those keys.
     """
     return _read_tsv_dicts(log_path)
 

--- a/tests/test_wpcom_adapter.py
+++ b/tests/test_wpcom_adapter.py
@@ -1357,6 +1357,21 @@ class TestLogging(unittest.TestCase):
         rows = parse_change_log(self.changes)
         self.assertEqual(rows[0]['old_categories'], '')
 
+    def test_set_post_categories_logs_slugs(self):
+        """The change log records category slugs so revert can resolve by
+        the stable, unique key rather than the ambiguous display name."""
+        adapter = FakeWpcom(cats=_make_cats(), posts=_make_posts())
+        adapter.set_logging(changes_log_path=self.changes)
+        adapter.set_post_categories(
+            123, [1, 2], old_category_ids=[2], post_title='Hello',
+        )
+        from helpers import parse_change_log
+        rows = parse_change_log(self.changes)
+        self.assertEqual(rows[0]['old_category_slugs'], 'tech')
+        self.assertEqual(
+            set(rows[0]['new_category_slugs'].split('|')), {'general', 'tech'},
+        )
+
     def test_set_default_logs(self):
         adapter = FakeWpcom(cats=_make_cats())
         adapter.set_logging(terms_log_path=self.terms)
@@ -1404,6 +1419,66 @@ class TestRestoreFromLogs(unittest.TestCase):
             dry_run=False,
         )
         return adapter, result
+
+    def test_revert_resolves_duplicate_names_by_slug(self):
+        """Two categories can share a display name under different slugs.
+        Inverse-replay must restore the exact original category by slug,
+        not pick whichever same-named one is first in the cache."""
+        cats = {
+            1: {'ID': 1, 'name': 'General', 'slug': 'general',
+                'description': '', 'parent': 0, 'post_count': 0},
+            10: {'ID': 10, 'name': 'News', 'slug': 'news-sports',
+                 'description': '', 'parent': 0, 'post_count': 0},
+            20: {'ID': 20, 'name': 'News', 'slug': 'news-politics',
+                 'description': '', 'parent': 0, 'post_count': 0},
+        }
+        posts = {123: {'ID': 123, 'title': 'Hello',
+                       'categories': {'News': cats[20]}}}
+        adapter = FakeWpcom(cats=cats, posts=posts)
+        adapter.backup(self.backup)
+        adapter.set_logging(self.changes, self.terms)
+        # Apply moves the post from news-politics (20) to news-sports (10).
+        adapter.set_post_categories(
+            123, [10], old_category_ids=[20], post_title='Hello',
+        )
+        adapter.set_logging()
+        result = adapter.restore(
+            backup_path=self.backup,
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS, dry_run=False,
+        )
+        self.assertFalse(result['errors'])
+        restored = [c['ID'] for c in adapter.posts[123]['categories'].values()]
+        self.assertEqual(restored, [20])
+
+    def test_revert_handles_pipe_in_category_name(self):
+        """A '|' in a category name must not corrupt the revert: the slug
+        is the canonical key, the '|'-joined names are display-only."""
+        cats = {
+            1: {'ID': 1, 'name': 'General', 'slug': 'general',
+                'description': '', 'parent': 0, 'post_count': 0},
+            30: {'ID': 30, 'name': 'Tips | Tricks', 'slug': 'tips-tricks',
+                 'description': '', 'parent': 0, 'post_count': 0},
+        }
+        posts = {123: {'ID': 123, 'title': 'Hello',
+                       'categories': {'Tips | Tricks': cats[30]}}}
+        adapter = FakeWpcom(cats=cats, posts=posts)
+        adapter.backup(self.backup)
+        adapter.set_logging(self.changes, self.terms)
+        adapter.set_post_categories(
+            123, [1], old_category_ids=[30], post_title='Hello',
+        )
+        adapter.set_logging()
+        result = adapter.restore(
+            backup_path=self.backup,
+            changes_log_path=self.changes,
+            terms_log_path=self.terms,
+            mode=MODE_LOGS, dry_run=False,
+        )
+        self.assertFalse(result['errors'])
+        restored = [c['ID'] for c in adapter.posts[123]['categories'].values()]
+        self.assertEqual(restored, [30])
 
     def test_reverts_post_that_had_no_categories(self):
         """Inverse-replay must clear a post back to zero categories when


### PR DESCRIPTION
The wpcom change log stored category identities as display names joined with `|`, and inverse-replay resolved them back via the first name match. Two real-world failures fell out of that.

WordPress allows two categories to share a display name under different slugs. Reverting picked whichever same-named category was first in the cache, silently reassigning the post to the wrong one, on the undo path.

A category name containing `|` (e.g. `Tips | Tricks`) was split into phantom names on revert, 404ing and producing a partial restore.

Display names are also a poor revert key because a category deleted by the apply run and recreated during restore keeps its slug but gets a new term ID, so the slug is the only identifier that stays stable across a restore.

This adds `old_category_slugs` / `new_category_slugs` columns to the change log and resolves the `SET_CATS` inverse by slug, with a name-based fallback for logs written before the columns existed (or by the WP-CLI script). I updated the AGENTS.md schema and the `parse_change_log` docs, and added regression tests for the duplicate-name and `|`-in-name reverts.

I also confirmed it against a live Jetpack site: with two categories sharing the name "ZZ WP Dup" under different slugs, a logged change plus an inverse-replay restore put the post back on the exact original category by slug, not the same-named one.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
