### PR TITLE
Set WP-CLI post categories by term ID, not slug

### DIFF
--- a/lib/adapters/wp_cli_adapter.py
+++ b/lib/adapters/wp_cli_adapter.py
@@ -130,9 +130,19 @@ class WpCliAdapter:
         return output_path
 
     def set_post_categories(self, post_id, category_ids):
-        """Set categories for a post."""
-        ids_str = ','.join(map(str, category_ids))
-        return self._run_command(['post', 'term', 'set', str(post_id), 'category', ids_str])
+        """Set categories for a post by term ID.
+
+        Each term ID is passed as a separate positional argument with
+        --by=id. Comma-joining them into one token makes `wp post term
+        set` treat the value as a single slug; if no category has that
+        slug, wp silently CREATES a junk category named after the value
+        (e.g. setting term 390 created a category named "390"). --by=id
+        also stops a numeric term ID being matched against a slug.
+        """
+        args = ['post', 'term', 'set', str(post_id), 'category']
+        args.extend(str(cid) for cid in category_ids)
+        args.append('--by=id')
+        return self._run_command(args)
 
     def create_category(self, name, slug, description=''):
         """Create a new category."""

--- a/tests/test_wp_cli_adapter.py
+++ b/tests/test_wp_cli_adapter.py
@@ -98,5 +98,26 @@ class TestCreateCategoryInjection(unittest.TestCase):
         self.assertIn('--slug=tech', argv)
 
 
+class TestSetPostCategories(unittest.TestCase):
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_uses_by_id_and_separate_args(self, mock_run):
+        """Term IDs must be passed as separate positional args with
+        --by=id. Comma-joining them ('5,7') makes wp treat the value as a
+        single slug, not find it, and silently CREATE a junk category named
+        after the value (verified live: setting [390] created a category
+        named '390')."""
+        mock_run.return_value = _ok_run()
+        adapter = WpCliAdapter(_local_config())
+        adapter.set_post_categories(123, [5, 7])
+        argv = mock_run.call_args[0][0]
+        self.assertIn('--by=id', argv)
+        self.assertIn('5', argv)
+        self.assertIn('7', argv)
+        # The buggy version passed a single comma-joined '5,7' token.
+        self.assertNotIn('5,7', argv)
+        # Term values must come after the 'category' taxonomy positional.
+        self.assertEqual(argv[-3:], ['5', '7', '--by=id'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`set_post_categories` comma-joined the term IDs into a single token and passed it to `wp post term set` with no `--by` flag. wp defaults to matching by slug, so a numeric term ID like 390 was looked up as the slug "390"; when no such category existed, wp silently created a junk category named "390" and assigned it to the post. Comma-joining also broke multi-category assignment (the whole "5,7" string was treated as one slug).

I caught this with a live test on a real site: `set_post_categories(9082, [390])` produced a category named "390" instead of assigning term 390.

The fix passes each term ID as a separate positional argument with `--by=id`. I added a regression test asserting the argv shape, and re-confirmed on the live site that assigning by ID now works without creating junk categories.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
