### PR TITLE
Make the WP-CLI adapter work against real remote hosts

### DIFF
--- a/lib/adapters/wp_cli_adapter.py
+++ b/lib/adapters/wp_cli_adapter.py
@@ -5,6 +5,9 @@ import shlex
 import subprocess
 import tempfile
 
+# Directory holding the bundled PHP scripts (this file lives in lib/adapters/).
+_LIB_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 
 def _reject_option_like(value, label):
     """Refuse a value that could be parsed as a command-line option.
@@ -39,8 +42,15 @@ class WpCliAdapter:
         self.wp_cli_flags = self.connection.get('wp_cli_flags', '')
 
     def _wp_base_command(self):
-        """Build the base WP-CLI command as a list of safe argv tokens."""
-        cmd = ['wp', f'--path={self.wp_path}']
+        """Build the base WP-CLI command as a list of safe argv tokens.
+
+        No --path: the command is run from the WP directory instead (see
+        _run_command). wp-cli's --path doesn't follow a symlinked
+        wp-load.php (some managed hosts keep core in a separate directory
+        and symlink wp-load.php into the docroot), but running from the
+        directory resolves the install fine.
+        """
+        cmd = ['wp']
         if self.wp_cli_flags:
             cmd.extend(shlex.split(self.wp_cli_flags))
         return cmd
@@ -67,7 +77,12 @@ class WpCliAdapter:
         return result.stdout
 
     def _run_command(self, args, env=None):
-        """Build and run a WP-CLI command without invoking a local shell."""
+        """Build and run a WP-CLI command without invoking a local shell.
+
+        Runs from the configured WP directory (cd over SSH, cwd locally)
+        so wp-cli auto-detects the install even when wp-load.php is a
+        symlink.
+        """
         env = {key: str(value) for key, value in (env or {}).items()}
         cmd = [*self._wp_base_command(), *args]
 
@@ -76,15 +91,32 @@ class WpCliAdapter:
                 f'{key}={shlex.quote(value)}' for key, value in env.items()
             )
             quoted_cmd = ' '.join(shlex.quote(part) for part in cmd)
-            remote_cmd = f'{env_prefix} {quoted_cmd}'.strip()
+            cd_prefix = f'cd {shlex.quote(self.wp_path)} &&'
+            remote_cmd = ' '.join(
+                p for p in (cd_prefix, env_prefix, quoted_cmd) if p
+            )
             return self._run_remote_shell(remote_cmd)
 
         local_env = os.environ.copy()
         local_env.update(env)
-        result = subprocess.run(cmd, capture_output=True, text=True, env=local_env)
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, env=local_env,
+            cwd=self.wp_path,
+        )
         if result.returncode != 0:
             raise Exception(f'WP-CLI error: {result.stderr}')
         return result.stdout
+
+    def _upload(self, local_path, remote_path):
+        """Copy a local file to the remote host over scp."""
+        result = subprocess.run(
+            ['scp', '--', local_path,
+             f'{self._ssh_target()}:{remote_path}'],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise Exception(f'SCP upload error: {result.stderr}')
 
     def list_categories(self):
         """List all categories as JSON."""
@@ -95,17 +127,26 @@ class WpCliAdapter:
         return json.loads(output)
 
     def export_posts(self, output_path):
-        """Export posts using the lib/export-posts.php script."""
-        php_script = 'lib/export-posts.php'
+        """Export posts using the bundled export-posts.php script.
+
+        The script ships with this repo, not on the target, so it is
+        referenced by absolute path locally and uploaded before use over
+        SSH (the remote home is not the repo).
+        """
+        php_script = os.path.join(_LIB_DIR, 'export-posts.php')
 
         if self.method == 'wp-cli-ssh':
+            token = next(tempfile._get_candidate_names())
             remote_output = posixpath.join(
-                '/tmp',
-                f'taxonomist-export-{next(tempfile._get_candidate_names())}.json',
+                '/tmp', f'taxonomist-export-{token}.json',
+            )
+            remote_script = posixpath.join(
+                '/tmp', f'taxonomist-export-posts-{token}.php',
             )
             try:
+                self._upload(php_script, remote_script)
                 self._run_command(
-                    ['eval-file', php_script],
+                    ['eval-file', remote_script],
                     env={'TAXONOMIST_OUTPUT': remote_output},
                 )
                 result = subprocess.run(
@@ -118,7 +159,10 @@ class WpCliAdapter:
                     raise Exception(f'SCP error: {result.stderr}')
             finally:
                 try:
-                    self._run_remote_shell(f'rm -f -- {shlex.quote(remote_output)}')
+                    self._run_remote_shell(
+                        f'rm -f -- {shlex.quote(remote_output)} '
+                        f'{shlex.quote(remote_script)}'
+                    )
                 except Exception:
                     pass
             return output_path

--- a/tests/test_wp_cli_adapter.py
+++ b/tests/test_wp_cli_adapter.py
@@ -119,5 +119,72 @@ class TestSetPostCategories(unittest.TestCase):
         self.assertEqual(argv[-3:], ['5', '7', '--by=id'])
 
 
+class TestRunsFromWpPath(unittest.TestCase):
+    """The adapter must run wp from the WP directory rather than passing
+    --path, because --path doesn't follow a symlinked wp-load.php (some
+    managed hosts keep core in a separate directory and symlink wp-load.php
+    into the docroot)."""
+
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_local_uses_cwd_not_path_flag(self, mock_run):
+        mock_run.return_value = _ok_run()
+        adapter = WpCliAdapter(_local_config(wp_path='/srv/htdocs'))
+        adapter.list_categories()
+        argv = mock_run.call_args[0][0]
+        kwargs = mock_run.call_args[1]
+        self.assertEqual(kwargs.get('cwd'), '/srv/htdocs')
+        self.assertFalse(
+            any(str(a).startswith('--path=') for a in argv),
+            f'should not pass --path: {argv}',
+        )
+
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_ssh_cds_into_wp_path(self, mock_run):
+        mock_run.return_value = _ok_run()
+        adapter = WpCliAdapter(_ssh_config(wp_path='/srv/htdocs'))
+        adapter.list_categories()
+        remote_cmd = mock_run.call_args[0][0][-1]
+        self.assertIn('cd /srv/htdocs', remote_cmd)
+        self.assertNotIn('--path=', remote_cmd)
+
+
+class TestExportUploadsScript(unittest.TestCase):
+    """export_posts must not assume lib/export-posts.php already exists on
+    the target. Locally it uses an absolute path; over SSH it uploads the
+    script first and eval-files the uploaded copy."""
+
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_local_export_uses_absolute_script_path(self, mock_run):
+        mock_run.return_value = _ok_run()
+        adapter = WpCliAdapter(_local_config())
+        adapter.export_posts('/tmp/out.json')
+        argv = mock_run.call_args[0][0]
+        script = argv[argv.index('eval-file') + 1]
+        self.assertTrue(os.path.isabs(script), f'not absolute: {script}')
+        self.assertTrue(script.endswith('export-posts.php'))
+
+    @patch('adapters.wp_cli_adapter.subprocess.run')
+    def test_ssh_export_uploads_script_then_eval_files_it(self, mock_run):
+        mock_run.return_value = _ok_run()
+        adapter = WpCliAdapter(_ssh_config())
+        adapter.export_posts('/tmp/out.json')
+        calls = [c.args[0] for c in mock_run.call_args_list]
+        # An scp call that uploads the local export-posts.php to a remote path.
+        uploads = [
+            c for c in calls
+            if c[0] == 'scp'
+            and any(str(a).endswith('export-posts.php') for a in c)
+            and any(str(a).startswith('root@example.com:') for a in c)
+        ]
+        self.assertTrue(uploads, f'no script upload found: {calls}')
+        # The eval-file command must target the uploaded remote copy, not the
+        # repo-relative lib/export-posts.php.
+        evalfile_cmds = [
+            c[-1] for c in calls if c[0] == 'ssh' and 'eval-file' in c[-1]
+        ]
+        self.assertTrue(evalfile_cmds, f'no eval-file ssh call: {calls}')
+        self.assertNotIn('lib/export-posts.php', evalfile_cmds[0])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Two things kept the `wp-cli-ssh` adapter from working on some managed WordPress hosts, both found while testing against a real site.

The adapter passed `--path=<wp_path>` to every command, but wp-cli's `--path` doesn't follow a symlinked `wp-load.php`. Some hosts keep WordPress core in a separate directory and symlink `wp-load.php` into the docroot, so every command failed with "This does not seem to be a WordPress installation" even though the install was right there. Running wp from the WP directory instead (`cd` over SSH, `cwd` locally) resolves it, the way you'd run wp-cli by hand.

`export_posts` also ran `wp eval-file lib/export-posts.php` on the remote, which assumed this repo's PHP script already lived on the server. It doesn't, so the export failed before it started. Now the script is referenced by absolute path locally, and uploaded to a temp path on the remote before `eval-file` (and cleaned up afterward).

I verified both against a live managed-WordPress test site: with `wp_path` set to the site root (the exact value `--path` rejected), `list_categories` and a full 9,072-post export both came back clean. I added regression tests for the run-from-directory behavior and the script upload.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
