### PR TITLE
Document WordPress.com create_category slug and duplicate-name behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,14 @@ Key endpoints:
 - `POST /sites/$site/categories/slug:$slug` — update category
 - `POST /sites/$site/categories/slug:$slug/delete` — delete category
 
+Note: `categories/new` on WordPress.com behaves differently from WP-CLI in
+two ways (verified empirically). It **ignores the requested `slug`** and
+derives the slug from the name, so read the slug back from the response
+rather than assuming the one you sent. And it **rejects a duplicate display
+name** at the same level with a 400 ("A taxonomy with that name already
+exists"), where WP-CLI would allow two same-named categories under distinct
+slugs.
+
 Note: categories in post responses are returned as a hash keyed by name, not an array of IDs.
 Use exported `term_id` values as the canonical category identifier throughout
 analysis and apply. For category updates or deletes, resolve the exact

--- a/lib/adapters/wpcom_adapter.py
+++ b/lib/adapters/wpcom_adapter.py
@@ -636,14 +636,26 @@ class WpcomAdapter:
         """
         Create a new category.
 
+        Two WordPress.com /categories/new behaviors to know about (verified
+        empirically; they differ from WP-CLI):
+
+        - The `slug` argument is advisory. WP.com derives the slug from the
+          name and ignores the value sent here, so the returned category may
+          have a different slug than requested. Always read the slug back
+          from the returned dict rather than assuming the requested one.
+        - Duplicate display names at the same level are rejected with a 400
+          ("A taxonomy with that name already exists"), surfaced as a
+          WpcomApiError. WP-CLI allows same-name categories with distinct
+          slugs; WP.com does not.
+
         Args:
             name: Display name.
-            slug: URL slug.
+            slug: Requested URL slug (advisory on WP.com — see above).
             description: Category description.
             parent: Parent category ID (0 for top-level).
 
         Returns:
-            API response dict with the new category.
+            API response dict with the new category (use its `slug`).
         """
         data = {'name': name}
         if slug:


### PR DESCRIPTION
Testing against a live Jetpack site turned up two `categories/new` behaviors on WordPress.com that differ from WP-CLI and aren't obvious from the code:

- The endpoint ignores the `slug` you send and derives the slug from the name. The adapter passes the slug, but WP.com overrides it, so the created category can end up with a different slug than requested (requesting `zz-custom` for "ZZ Custom Name" gives `zz-custom-name`). Callers should read the slug back from the response.
- It rejects a duplicate display name at the same level with a 400 ("A taxonomy with that name already exists"). WP-CLI happily creates two same-named categories under different slugs; WP.com won't.

Neither breaks anything today (the adapter returns the real category, and the slug-based revert reads the actual slug from live data), but both are easy to trip over. This documents them in the `create_category` docstring and the AGENTS.md WordPress.com section. Docs only, no behavior change.

### Testing
- `python3 -m unittest discover tests` — green
- `ruff check lib/ tests/` — clean
